### PR TITLE
Postgres on K8s deployed using TravisCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ ubuntu-bionic-18.04-cloudimg-console.log
 /app/database/data_preparation/Python/__pycache__
 node_modules
 dist
+
+k8s/postgres.yaml
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ branches:
     - development
     - test_travis
 before_script:
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt` && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  - make setup-kube-config
 script:
   - make release-docker-image -e COMPONENT=client
   - make release-docker-image -e COMPONENT=api

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ branches:
 script:
   - make release-docker-image -e COMPONENT=client
   - make release-docker-image -e COMPONENT=api
+  - make deploy-postgres-server
 after_success:
   - make after-success
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ branches:
     - master
     - development
     - test_travis
+before_script:
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt` && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 script:
   - make release-docker-image -e COMPONENT=client
   - make release-docker-image -e COMPONENT=api

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ K8S_OBJ:=$(patsubst %.tpl.yaml,%.yaml,$(K8S_SRC))
 	DOCKER_IMAGE=$(DOCKER_IMAGE) \
 	NAMESPACE=$(NAMESPACE) \
 	VERSION=$(VERSION) \
+	POSTGRES_DB=$(POSTGRES_DB) \
+	POSTGRES_USER=$(POSTGRES_USER) \
+	POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
 	t=$$(cat $<); eval "echo \"$${t}\"" > $@
 
 # target: make help - displays this help.
@@ -58,3 +61,15 @@ release-docker-image: docker-login build-docker-image
 .PHONY: after-success
 after-success:
 	@echo "Hooray! :)"
+
+# target: make build-k8s VERSION=some_git_sha_comit
+.PHONY: build-k8s
+build-k8s:
+	rm -f $(K8S_OBJ)
+	make $(K8S_OBJ)
+	@echo "Built k8s/*.yaml from k8s/*.tpl.yaml"
+
+# target: make deploy-postgres-server
+.PHONY: deploy-postgres-server
+deploy-postgres-server: build-k8s
+	$(KCTL) config use-context goat && $(KCTL) apply -f k8s/postgres.yaml

--- a/k8s/config
+++ b/k8s/config
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data:
+    server:
+  name: "goat"
+contexts:
+- context:
+    cluster: "goat"
+    user: "goat-admin"
+  name: "goat"
+current-context: "goat"
+kind: Config
+users:
+- name: goat-admin
+  user:
+    token:
+---

--- a/k8s/postgres.tpl.yaml
+++ b/k8s/postgres.tpl.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgres
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  namespace: postgres
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: ${POSTGRES_DB}
+  POSTGRES_USER: ${POSTGRES_USER}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pv-claim
+  namespace: postgres
+  labels:
+    app: postgres
+spec:
+  storageClassName: do-block-storage
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:10.4
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: postgres-config
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgredb
+      volumes:
+        - name: postgredb
+          persistentVolumeClaim:
+            claimName: postgres-pv-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: postgres
+  labels:
+    app: postgres
+spec:
+  type: NodePort
+  ports:
+   - port: 5432
+  selector:
+   app: postgres
+---


### PR DESCRIPTION
- Configure TravisCI to have access to K8s over Kubectl.
- Deploy `porstgres` on K8s with DigitalOcean volume claims (for persistency).