### PR TITLE
precalculate_grid now uses the new pgrouting_edges_multi function.

### DIFF
--- a/app/database/database_functions/heatmap/precalculate_grid.sql
+++ b/app/database/database_functions/heatmap/precalculate_grid.sql
@@ -1,86 +1,66 @@
 DROP FUNCTION IF EXISTS precalculate_grid;
-CREATE OR REPLACE FUNCTION public.precalculate_grid(userid_input integer, grid text, minutes integer,array_starting_points NUMERIC[][],speed NUMERIC, objectids int[], modus_input integer,routing_profile text)
+CREATE OR REPLACE FUNCTION public.precalculate_grid(userid_input integer, objectid_input integer, grid text, minutes integer,array_starting_points NUMERIC[][],speed NUMERIC, ids_calc int[], modus_input integer,routing_profile text)
 RETURNS SETOF type_catchment_vertices_single
- LANGUAGE plpgsql
+LANGUAGE plpgsql
 AS $function$
 DECLARE 
 	i integer;
-	count_vertices integer;
-	excluded_class_id integer[];
-	categories_no_foot text[];
-	max_length_links integer;
-	buffer text;
-    buffer_point geometry;
-	distance integer;
-	cnt integer := 0;
+
+	--new
+	number_isochrones integer := 1;	
+	calc_step integer := 900;	
+
 BEGIN 
 
-	DROP TABLE IF EXISTS temp_multi_reached_vertices;
-	DROP TABLE IF EXISTS temp_all_extrapolated_vertices;
-	CREATE temp TABLE temp_multi_reached_vertices AS 
-	SELECT *
-	FROM pgrouting_edges_multi(1,minutes,array_starting_points,speed,objectids,1,routing_profile);
+	DELETE FROM edges_multi;
+	DELETE FROM edges_multi_extrapolated;
+	PERFORM pgrouting_edges_multi(userid_input, minutes, array_starting_points, speed, number_isochrones, ids_calc, objectid_input, modus_input, routing_profile);
 
-	ALTER TABLE temp_multi_reached_vertices ADD COLUMN id serial;
-	ALTER TABLE temp_multi_reached_vertices ADD PRIMARY key(id);
-	
-	SELECT select_from_variable_container('excluded_class_id_walking')::text[],
-	select_from_variable_container('categories_no_foot')::text,
-	select_from_variable_container_s('max_length_links')
-	INTO excluded_class_id, categories_no_foot, max_length_links;
-	
-	FOR i IN SELECT DISTINCT objectid FROM temp_multi_reached_vertices ORDER BY objectid
+	FOREACH i IN ARRAY ids_calc
 	LOOP 
-		raise notice '%', cnt;
-		cnt = cnt + 1;
-		DROP TABLE IF EXISTS temp_reached_vertices;	
+
 		DROP TABLE IF EXISTS temp_extrapolated_reached_vertices;
 		
-	    CREATE temp TABLE temp_reached_vertices AS 
-		SELECT start_vertex, node, edge, cost, geom, objectid 
-		FROM temp_multi_reached_vertices
-		WHERE objectid = i;
-	
+		CREATE TEMP TABLE temp_extrapolated_reached_vertices AS
+		SELECT v_geom AS geom, cost
+   		FROM edges_multi_extrapolated
+    	WHERE objectid = 100
+    	AND cost = 900 
+    	UNION ALL
+    	SELECT v_geom AS geom, greatest(COALESCE((node_cost_1 -> '1')::float,0),
+    	COALESCE((node_cost_2 -> '1')::float,0)) AS cost
+    	FROM edges_multi
+    	WHERE objectid = 100
+    	AND	((node_cost_1 -> '1') IS NOT NULL OR (node_cost_2 -> '1') IS NOT NULL)
+		AND greatest(COALESCE((node_cost_1 -> '1')::float,0),
+    		COALESCE((node_cost_1 -> '1')::float,0)) < 900;
+    	
+    	CREATE INDEX ON temp_extrapolated_reached_vertices USING gist(geom);
+    	ALTER TABLE temp_extrapolated_reached_vertices ADD COLUMN id serial;
+		ALTER TABLE temp_extrapolated_reached_vertices ADD PRIMARY key(id);
+						
 
-   		buffer_point = ST_SetSRID(ST_MakePoint(array_starting_points[cnt][1],array_starting_points[cnt][2]), 4326);
-    	distance = minutes*60*(speed/3.6);
-    	buffer = ST_AsText(ST_Buffer(buffer_point::geography,distance)::geometry);
-		
-		raise notice '%', ST_ASTEXT(buffer_point);
-		raise notice '%', buffer;
-		raise notice '%', i;
-		raise notice '%', cnt;
-		IF (SELECT count(*)	FROM temp_reached_vertices LIMIT 4) > 3 THEN 
-			
-			CREATE temp TABLE temp_extrapolated_reached_vertices AS 
-			SELECT * 
-			FROM extrapolate_reached_vertices(minutes*60,max_length_links,buffer,(speed/3.6),userid_input,modus_input,routing_profile);
-
-			ALTER TABLE temp_extrapolated_reached_vertices ADD COLUMN id serial;
-			ALTER TABLE temp_extrapolated_reached_vertices ADD PRIMARY key(id);
-			CREATE INDEX ON temp_extrapolated_reached_vertices USING gist(geom);
-		
-			DROP TABLE IF EXISTS isochrone;
-			CREATE temp TABLE isochrone AS 
-			SELECT ST_area(ST_convexhull(ST_collect(geom))::geography) AS area,ST_convexhull(ST_collect(geom)) AS geom
-			FROM temp_extrapolated_reached_vertices;
+		DROP TABLE IF EXISTS isochrone;
+		CREATE temp TABLE isochrone AS 
+		SELECT ST_area(ST_convexhull(ST_collect(geom))::geography) AS area,ST_convexhull(ST_collect(geom)) AS geom
+		FROM temp_extrapolated_reached_vertices;
 			/*Isochrone calculation should be changed to alpha-shape. Challenge when network is not dense.*/
 			--ST_setSRID(pgr_pointsaspolygon,4326) AS geom 
 			--FROM pgr_pointsaspolygon('select node id,st_x(geom) x,st_y(geom) y FROM temp_extrapolated_reached_vertices',0.000005); 
 			
-			EXECUTE format('
+		EXECUTE format('
 			UPDATE '||grid||' set pois = closest_pois, area_isochrone = x.area
 			FROM (
 				SELECT i.area, closest_pois(0.0009)
 				FROM isochrone i
 			) x
 			WHERE grid_id = '||i
-			);
-			
-		END IF; 
-	
+		);
+				
 		END LOOP;
 END 
 $function$;
 
---SELECT * FROM precalculate_grid(1,'grid_500',15,array[[11.5669,48.1546],[11.5788,48.1545]],5,	array[1,2],1,'walking_standard');
+--SELECT * FROM public.precalculate_grid(100, 100, 'grid_500'::TEXT, 15, ARRAY[[11.2570,48.1841]], 5, ARRAY[1], 1, 'walking_standard');
+
+


### PR DESCRIPTION
A union is created from the tables called edges_multi_extrapolated and edges_multi (these come from the new pgrouting_edges_multi function).
From this union, the temporary tables are created, which the closest_pois function uses in the end to write reached pois into grid_500.