### PR TITLE
Insert link to GOAT technical documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ For more information:
 
 [GOAT Docs](https://plan4better.de/docs/background/)
 
+[GOAT Technical Docs](https://www.open-accessibility.org/docs/quick_start_docker/)
+
 [GOAT demo versions](https://plan4better.de/goatlive/)
 
 [Join GOAT User Group on Telegram](https://t.me/joinchat/EpAk7BYbIF72q7D3OTUCZQ)


### PR DESCRIPTION
Hi,

I thought that it would be useful to include the link to the technical documentation of GOAT.