### PR TITLE
Layer library endpoint

### DIFF
--- a/app/api/src/db/models/layer_library.py
+++ b/app/api/src/db/models/layer_library.py
@@ -33,11 +33,7 @@ class StyleLibrary(SQLModel, table=True):
 UniqueConstraint(StyleLibrary.__table__.c.name)
 
 
-class LayerLibrary(SQLModel, table=True):
-    __tablename__ = "layer_library"
-    __table_args__ = {"schema": "customer"}
-
-    id: Optional[int] = Field(sa_column=Column(Integer, primary_key=True, autoincrement=True))
+class LayerLibraryBase(SQLModel):
     name: str = Field(sa_column=Column(Text(), nullable=False, index=True))
     url: Optional[str] = Field(sa_column=Column(Text))
     legend_urls: Optional[List[str]] = Field(sa_column=Column(ARRAY(Text())))
@@ -46,6 +42,20 @@ class LayerLibrary(SQLModel, table=True):
     type: str = Field(sa_column=Column(Text(), nullable=False, index=True))
     map_attribution: Optional[str] = Field(sa_column=Column(Text))
     date: Optional[datetime] = Field(sa_column=Column(Text))
+    source: Optional[str]
+    date_1: Optional[datetime] = Field(sa_column=Column(Text))
+    source_1: Optional[str]
+    style_library_name: Optional[str]
+    max_resolution: Optional[float] = Field(sa_column=Column(Text, nullable=True))
+    min_resolution: Optional[float] = Field(sa_column=Column(Text, nullable=True))
+    style_library: "StyleLibrary"
+
+
+class LayerLibrary(LayerLibraryBase, table=True):
+    __tablename__ = "layer_library"
+    __table_args__ = {"schema": "customer"}
+
+    id: Optional[int] = Field(sa_column=Column(Integer, primary_key=True, autoincrement=True))
     source: Optional[str] = Field(
         sa_column=Column(
             Text,
@@ -53,7 +63,6 @@ class LayerLibrary(SQLModel, table=True):
             nullable=True,
         )
     )
-    date_1: Optional[datetime] = Field(sa_column=Column(Text))
     source_1: Optional[str] = Field(
         sa_column=Column(
             Text,
@@ -68,8 +77,6 @@ class LayerLibrary(SQLModel, table=True):
             nullable=True,
         )
     )
-    max_resolution: Optional[float] = Field(sa_column=Column(Text, nullable=True))
-    min_resolution: Optional[float] = Field(sa_column=Column(Text, nullable=True))
 
     style_library: "StyleLibrary" = Relationship(back_populates="layer_libraries")
 

--- a/app/api/src/db/models/layer_library.py
+++ b/app/api/src/db/models/layer_library.py
@@ -1,21 +1,23 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import (
+    ARRAY,
     Column,
     Field,
     ForeignKey,
     Integer,
+    Relationship,
     SQLModel,
     Text,
     UniqueConstraint,
-    Relationship,
-    ARRAY
 )
-from sqlalchemy.dialects.postgresql import JSONB
+
 if TYPE_CHECKING:
     from .data_upload import DataUpload
     from .scenario import Scenario
+
 
 class StyleLibrary(SQLModel, table=True):
     __tablename__ = "style_library"
@@ -30,6 +32,7 @@ class StyleLibrary(SQLModel, table=True):
 
 UniqueConstraint(StyleLibrary.__table__.c.name)
 
+
 class LayerLibrary(SQLModel, table=True):
     __tablename__ = "layer_library"
     __table_args__ = {"schema": "customer"}
@@ -37,16 +40,12 @@ class LayerLibrary(SQLModel, table=True):
     id: Optional[int] = Field(sa_column=Column(Integer, primary_key=True, autoincrement=True))
     name: str = Field(sa_column=Column(Text(), nullable=False, index=True))
     url: Optional[str] = Field(sa_column=Column(Text))
-    legend_urls: List[str] = Field(
-        sa_column=Column(ARRAY(Text()))
-    )
+    legend_urls: Optional[List[str]] = Field(sa_column=Column(ARRAY(Text())))
     special_attribute: Optional[dict] = Field(sa_column=Column(JSONB))
     access_token: Optional[str] = Field(sa_column=Column(Text))
     type: str = Field(sa_column=Column(Text(), nullable=False, index=True))
     map_attribution: Optional[str] = Field(sa_column=Column(Text))
-    date: Optional[datetime] = Field(
-        sa_column=Column(Text)
-    )
+    date: Optional[datetime] = Field(sa_column=Column(Text))
     source: Optional[str] = Field(
         sa_column=Column(
             Text,
@@ -54,9 +53,7 @@ class LayerLibrary(SQLModel, table=True):
             nullable=True,
         )
     )
-    date_1: Optional[datetime] = Field(
-        sa_column=Column(Text)
-    )
+    date_1: Optional[datetime] = Field(sa_column=Column(Text))
     source_1: Optional[str] = Field(
         sa_column=Column(
             Text,
@@ -64,21 +61,18 @@ class LayerLibrary(SQLModel, table=True):
             nullable=True,
         )
     )
-    style_library_name: str = Field(
+    style_library_name: Optional[str] = Field(
         sa_column=Column(
             Text,
             ForeignKey("customer.style_library.name", onupdate="CASCADE"),
             nullable=True,
         )
     )
-    max_resolution: Optional[float] = Field(
-        sa_column=Column(Text, nullable=True)
-    )
-    min_resolution: Optional[float] = Field(
-        sa_column=Column(Text, nullable=True)
-    )
-    
+    max_resolution: Optional[float] = Field(sa_column=Column(Text, nullable=True))
+    min_resolution: Optional[float] = Field(sa_column=Column(Text, nullable=True))
+
     style_library: "StyleLibrary" = Relationship(back_populates="layer_libraries")
+
 
 UniqueConstraint(LayerLibrary.__table__.c.name)
 
@@ -89,4 +83,6 @@ class LayerSource(SQLModel, table=True):
 
     id: Optional[int] = Field(sa_column=Column(Integer, primary_key=True, autoincrement=True))
     name: str = Field(sa_column=Column(Text(), nullable=False, index=True))
+
+
 UniqueConstraint(LayerSource.__table__.c.name)

--- a/app/api/src/endpoints/v1/api.py
+++ b/app/api/src/endpoints/v1/api.py
@@ -5,6 +5,7 @@ from src.endpoints.v1 import (
     heatmap,
     isochrones,
     layers,
+    layer_library,
     login,
     organizations,
     poi_aoi,
@@ -43,3 +44,4 @@ layer_tiles = layers.VectorTilerFactory(
 )
 
 api_router.include_router(layer_tiles.router, prefix=layer_tiles_prefix, tags=["Layers"])
+api_router.include_router(layer_library.router, prefix= "/layers/library", tags= ["Layer Library"])

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.endpoints import deps
+from src.db import models
+from typing import List
+from src import crud
+
+router = APIRouter()
+
+@router.get("",response_model=List[models.LayerLibrary])
+async def get_layers(
+    db: AsyncSession = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps.get_current_active_user),
+):
+    layers = await crud.layer_library.get_multi(db, skip=skip, limit=limit)
+    return layers

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -42,7 +42,7 @@ async def create_layer(
     return layer
 
 
-@router.put("/{id}/", response_model=models.LayerLibrary)
+@router.put("/{id}", response_model=models.LayerLibrary)
 async def update_layer(
     id: int,
     layer_in: models.LayerLibrary,
@@ -54,7 +54,7 @@ async def update_layer(
     return layer
 
 
-@router.delete("/{id}/", response_model=models.LayerLibrary)
+@router.delete("/{id}", response_model=models.LayerLibrary)
 async def delete_layer(
     id: int,
     db: AsyncSession = Depends(deps.get_db),

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.get("", response_model=List[models.LayerLibrary])
-async def read_layers(
+async def list_layers(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
@@ -43,7 +43,7 @@ async def create_layer(
 
 
 @router.put("/{id}/", response_model=models.LayerLibrary)
-async def create_layer(
+async def update_layer(
     id: int,
     layer_in: models.LayerLibrary,
     db: AsyncSession = Depends(deps.get_db),
@@ -51,4 +51,14 @@ async def create_layer(
 ):
     layer = await crud.layer_library.get(db, id=id)
     layer = await crud.layer_library.update(db, db_obj=layer, obj_in=layer_in)
+    return layer
+
+
+@router.delete("/{id}/", response_model=models.LayerLibrary)
+async def delete_layer(
+    id: int,
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    layer = await crud.layer_library.remove(db, id=id)
     return layer

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -10,7 +10,7 @@ from src.endpoints import deps
 router = APIRouter()
 
 
-@router.get("")
+@router.get("", response_model=List[models.LayerLibrary])
 async def read_layers(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
@@ -21,13 +21,14 @@ async def read_layers(
     return layers
 
 
-@router.get("/{layer_name}", response_model=models.LayerLibrary)
+@router.get("/{name}", response_model=models.LayerLibrary)
 async def read_layer_by_name(
-    layer_name: str,
+    name: str,
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_user),
 ):
-    layer = await crud.layer_library.get_by_key(db, key="name", value=layer_name)
+    layer = await crud.layer_library.get_by_key(db, key="name", value=name)
+    layer = layer[0]
     return layer
 
 
@@ -37,5 +38,17 @@ async def create_layer(
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    layer = crud.layer_library.create(db, obj_in=layer_in)
+    layer = await crud.layer_library.create(db, obj_in=layer_in)
+    return layer
+
+
+@router.put("/{id}/", response_model=models.LayerLibrary)
+async def create_layer(
+    id: int,
+    layer_in: models.LayerLibrary,
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    layer = await crud.layer_library.get(db, id=id)
+    layer = await crud.layer_library.update(db, db_obj=layer, obj_in=layer_in)
     return layer

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -1,13 +1,16 @@
-from fastapi import APIRouter, Depends, Body
-from sqlalchemy.ext.asyncio import AsyncSession
-from src.endpoints import deps
-from src.db import models
 from typing import List
+
+from fastapi import APIRouter, Body, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from src import crud
+from src.db import models
+from src.endpoints import deps
 
 router = APIRouter()
 
-@router.get("",response_model=List[models.LayerLibrary])
+
+@router.get("")
 async def read_layers(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
@@ -17,20 +20,22 @@ async def read_layers(
     layers = await crud.layer_library.get_multi(db, skip=skip, limit=limit)
     return layers
 
+
 @router.get("/{layer_name}", response_model=models.LayerLibrary)
 async def read_layer_by_name(
     layer_name: str,
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_user),
 ):
-    layer = await crud.layer_library.get_by_key(db,key="name", value=layer_name)
+    layer = await crud.layer_library.get_by_key(db, key="name", value=layer_name)
     return layer
 
-router.post("", response_model=models.LayerLibrary)
+
+@router.post("", response_model=models.LayerLibrary)
 async def create_layer(
+    layer_in: models.LayerLibrary,
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
-    layer_in: models.LayerLibrary = Body()
 ):
-    layer = crud.layer_library.create(db,obj_in=layer_in)
+    layer = crud.layer_library.create(db, obj_in=layer_in)
     return layer

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -8,7 +8,7 @@ from src import crud
 router = APIRouter()
 
 @router.get("",response_model=List[models.LayerLibrary])
-async def get_layers(
+async def read_layers(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -16,3 +16,12 @@ async def read_layers(
 ):
     layers = await crud.layer_library.get_multi(db, skip=skip, limit=limit)
     return layers
+
+@router.get("/{layer_name}")
+async def read_layer_by_name(
+    layer_name: str,
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_active_user),
+):
+    layer = await crud.layer_library.get_by_key(db,key="name", value=layer_name)
+    return layer

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Body
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.endpoints import deps
 from src.db import models
@@ -17,11 +17,20 @@ async def read_layers(
     layers = await crud.layer_library.get_multi(db, skip=skip, limit=limit)
     return layers
 
-@router.get("/{layer_name}")
+@router.get("/{layer_name}", response_model=models.LayerLibrary)
 async def read_layer_by_name(
     layer_name: str,
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_user),
 ):
     layer = await crud.layer_library.get_by_key(db,key="name", value=layer_name)
+    return layer
+
+router.post("", response_model=models.LayerLibrary)
+async def create_layer(
+    db: AsyncSession = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_active_superuser),
+    layer_in: models.LayerLibrary = Body()
+):
+    layer = crud.layer_library.create(db,obj_in=layer_in)
     return layer


### PR DESCRIPTION
There is an error:

`sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/14/xd2s)`

When we try to list layer libraries through the endpoint:

`api/v1/layers/library`