### PR TITLE
[FIX] Err when while update user without study ...

### DIFF
--- a/app/api/src/crud/crud_user.py
+++ b/app/api/src/crud/crud_user.py
@@ -44,7 +44,7 @@ class CRUDUser(CRUDBase[models.User, UserCreate, UserUpdate]):
             )
             db_obj.roles = roles.scalars().all()
             del update_data["roles"]
-        if update_data.get("study_areas") or len(update_data["study_areas"]) == 0:
+        if update_data.get("study_areas") or update_data.get("study_areas") == []:
             study_areas = await db.execute(
                 select(models.StudyArea).filter(models.StudyArea.id.in_(obj_in.study_areas))
             )


### PR DESCRIPTION
Fix error 500 while update user preferences without `study_area` in payload.


## Related Issue
closes #1381

## How Has This Been Tested?
Tested with the following curl (**token should be added**). Updated user after applying the fix.

`curl 'http://localhost:8000/api/v1/users/119'   -X 'PUT'   -H 'Accept: application/json, text/plain, */*'   -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8,fa;q=0.7'   -H 'Authorization: bearer <some_token>'   -H 'Connection: keep-alive'   -H 'Content-Type: application/json'   -H 'Origin: http://localhost:3000'   -H 'Referer: http://localhost:3000/'   -H 'Sec-Fetch-Dest: empty'   -H 'Sec-Fetch-Mode: cors'   -H 'Sec-Fetch-Site: same-site'   -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36'   -H 'sec-ch-ua: ".Not/A)Brand";v="99", "Google Chrome";v="103", "Chromium";v="103"'   -H 'sec-ch-ua-mobile: ?0'   -H 'sec-ch-ua-platform: "macOS"'   --data-raw '{"password":"some_hash","is_active":true,"newsletter":false,"occupation":"Student","domain":"test","name":"Name","surname":"Surename","email":"example@plan4better.de","organization_id":4,"active_study_area_id":91620000,"active_data_upload_ids":[],"storage":512000,"limit_scenarios":50,"language_preference":"de","roles":[]}'   --compressed`



