### PR TITLE
[FIX] grid_data types at isochrone.py

### DIFF
--- a/app/api/src/core/isochrone.py
+++ b/app/api/src/core/isochrone.py
@@ -68,14 +68,14 @@ class Isochrone(Dijkstra):
         grid_data = {}
         Z = np.ravel(self.Z)
         z_diff = np.diff(Z, prepend=0)
-        grid_data["version"] = grid_type
+        grid_data["version"] = 1
         grid_data["zoom"] = zoom
         grid_data["west"] = self.X.min()
         grid_data["north"] = self.Y.max()
-        grid_data["width"] = len(self.X)
-        grid_data["height"] = len(self.Y)
+        grid_data["width"] = self.Z.shape[0]
+        grid_data["height"] = self.Z.shape[1]
         grid_data["depth"] = 1
-        grid_data["data"] = z_diff.astype(np.int32)
+        grid_data["data"] = z_diff
 
         return grid_data
 

--- a/app/api/src/crud/crud_isochrone.py
+++ b/app/api/src/crud/crud_isochrone.py
@@ -22,6 +22,7 @@ from shapely.ops import unary_union
 from sqlalchemy import intersect
 from sqlalchemy.ext.asyncio.session import AsyncSession
 from sqlalchemy.sql import text
+from urllib3 import HTTPResponse
 
 from src.core.config import settings
 from src.core.isochrone import isochrone_single_depth_grid
@@ -724,10 +725,11 @@ class CRUDIsochrone:
             print("Fetched network...")
             # === Compute Grid ===#
             grid = isochrone_single_depth_grid(network, starting_ids, [25])
-            print("Created Grid")
+            print("Created Grid...")
+
             # === Amenity Intersect ===#
             intersects = await self.__amenity_intersect(grid, 25)
-            return intersects
+            return HTTPResponse("finished")
         else:
             payload = {
                 "accessModes": obj_in.settings.access_mode.value.upper(),

--- a/app/api/src/utils.py
+++ b/app/api/src/utils.py
@@ -352,7 +352,7 @@ def compute_single_value_surface(width, height, depth, data, percentile) -> Any:
     return surface
 
 
-@njit
+# @njit
 def amenity_r5_grid_intersect(
     west,
     north,


### PR DESCRIPTION
- :warning: removed the njit compiler at utils.py@line355.
- if we have the decorator, it will get numba error

Related issue: #1353