### PR TITLE
Rewrite database functions

### DIFF
--- a/app/api/src/core/config.py
+++ b/app/api/src/core/config.py
@@ -122,6 +122,8 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD_STAGING: Optional[str] = "secret"
     POSTGRES_OUTER_PORT_STAGING: Optional[int] = 5432
 
+    POSTGRES_FUNCTIONS_SCHEMA: Optional[str] = "temp_for_test_functions"
+
     DEMO_USER_STUDY_AREA_ID: Optional[int] = 91620000  # Munich
     DEMO_USER_SCENARIO_LIMIT: Optional[int] = 5
     DEMO_USER_STORAGE: Optional[int] = 0  # In kilobytes

--- a/app/api/src/core/config.py
+++ b/app/api/src/core/config.py
@@ -122,7 +122,7 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD_STAGING: Optional[str] = "secret"
     POSTGRES_OUTER_PORT_STAGING: Optional[int] = 5432
 
-    POSTGRES_FUNCTIONS_SCHEMA: Optional[str] = "temp_for_test_functions"
+    POSTGRES_FUNCTIONS_SCHEMA: Optional[str] = "basic"
 
     DEMO_USER_STUDY_AREA_ID: Optional[int] = 91620000  # Munich
     DEMO_USER_SCENARIO_LIMIT: Optional[int] = 5

--- a/app/api/src/db/sql/functions/helper/coordinate_to_pixel.sql
+++ b/app/api/src/db/sql/functions/helper/coordinate_to_pixel.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION basic.coordinate_to_pixel(lat double precision, lon double precision, zoom integer)
+ RETURNS integer[]
+ LANGUAGE plpgsql
+ IMMUTABLE
+AS $function$
+DECLARE
+invCos float;
+tan float;
+ln float;
+lon_pixel integer;
+lat_pixel integer;
+rds float;
+BEGIN
+rds = (lat * pi()) / 180;
+invCos = 1 / cos(rds);
+tan = tan(rds);
+ln = ln(tan + invCos);
+lat_pixel = ((1 - (ln / pi())) * pow(2, zoom - 1) * 256);
+lon_pixel = ((lon + 180) / 360 * pow(2, zoom) * 256);
+RETURN ARRAY[lat_pixel, lon_pixel];
+END
+$function$
+;

--- a/app/api/src/db/sql/init_sql.py
+++ b/app/api/src/db/sql/init_sql.py
@@ -3,28 +3,74 @@ from pathlib import Path
 from alembic_utils.pg_function import PGFunction
 from alembic_utils.pg_trigger import PGTrigger
 from alembic_utils.pg_view import PGView
+from sqlalchemy import text
+
+from src.core.config import settings
+from src.db.session import legacy_engine
+from src.db.sql.utils import sorted_path_by_dependency
 
 
 def sql_function_entities():
     sql_function_entities = []
-
-    for p in Path(str(Path().resolve()) + "/src/db/sql/functions").rglob('*.sql'):
+    function_paths = Path(str(Path().resolve()) + "/src/db/sql/functions").rglob("*.sql")
+    function_paths = sorted_path_by_dependency(function_paths)
+    for p in function_paths:
         pg_function_entitity = PGFunction.from_sql(p.read_text())
+        pg_function_entitity.schema = settings.POSTGRES_FUNCTIONS_SCHEMA
         sql_function_entities.append(pg_function_entitity)
     return sql_function_entities
 
 
-def sql_view_entities():
-    sql_view_entities = []
-    for p in Path("./views").glob("*.sql"):
-        pg_view_entity = PGView.from_sql(p.read_text())
-        sql_view_entities.append(pg_view_entity)
-    return sql_view_entities
+# def sql_view_entities():
+#     sql_view_entities = []
+#     for p in Path(str(Path().resolve()) + "./views").glob("*.sql"):
+#         pg_view_entity = PGView.from_sql(p.read_text())
+#         sql_view_entities.append(pg_view_entity)
+#     return sql_view_entities
 
 
 def sql_trigger_entities():
+
+    triger_paths = Path(str(Path().resolve()) + "/src/db/sql/triggers").glob("*.sql")
+    triger_paths = sorted_path_by_dependency(triger_paths)
     sql_trigger_entities = []
-    for p in Path("./triggers").glob("*.sql"):
-        pg_trigger_entity = PGTrigger.from_sql(p.read_text())
+    for p in triger_paths:
+        pg_trigger_entity = PGFunction.from_sql(p.read_text())
+        pg_trigger_entity.schema = settings.POSTGRES_FUNCTIONS_SCHEMA
         sql_trigger_entities.append(pg_trigger_entity)
     return sql_trigger_entities
+
+
+def downgrade_functions():
+    sql_function_entities_ = sql_function_entities()
+    sql_function_entities_.reverse()
+    for function in sql_function_entities_:
+        statement = function.to_sql_statement_drop()
+        legacy_engine.execute(text(statement.text))
+
+
+def upgrade_functions():
+    sql_function_entities_ = sql_function_entities()
+    for function in sql_function_entities_:
+        for statement in function.to_sql_statement_create_or_replace():
+            legacy_engine.execute(text(statement.text))
+
+
+def downgrade_triggers():
+    sql_trigger_entities_ = sql_trigger_entities()
+    sql_trigger_entities_.reverse()
+    for triger in sql_trigger_entities_:
+        statement = triger.to_sql_statement_drop()
+        legacy_engine.execute(text(statement.text))
+
+
+def upgrade_triggers():
+    sql_trigger_entities_ = sql_trigger_entities()
+    for triger in sql_trigger_entities_:
+        for statement in triger.to_sql_statement_create_or_replace():
+            legacy_engine.execute(text(statement.text))
+
+
+if __name__ == "__main__":
+    upgrade_functions()
+    print()

--- a/app/api/src/db/sql/triggers/trigger_insert_way_modified.sql
+++ b/app/api/src/db/sql/triggers/trigger_insert_way_modified.sql
@@ -6,6 +6,6 @@ BEGIN
 END;
 $trigger_insert_way_modified$ LANGUAGE plpgsql;
 
---DROP TRIGGER IF EXISTS trigger_insert_way_modified ON customer.way_modified; 
+DROP TRIGGER IF EXISTS trigger_insert_way_modified ON customer.way_modified; 
 CREATE TRIGGER trigger_insert_way_modified AFTER INSERT ON customer.way_modified
 FOR EACH ROW EXECUTE PROCEDURE basic.trigger_insert_way_modified();

--- a/app/api/src/db/sql/triggers/trigger_update_way_modified.sql
+++ b/app/api/src/db/sql/triggers/trigger_update_way_modified.sql
@@ -6,6 +6,6 @@ BEGIN
 END;
 $trigger_update_way_modified$ LANGUAGE plpgsql;
 
---DROP TRIGGER IF EXISTS trigger_update_way_modified ON customer.way_modified; 
+DROP TRIGGER IF EXISTS trigger_update_way_modified ON customer.way_modified; 
 CREATE TRIGGER trigger_update_way_modified AFTER UPDATE ON customer.way_modified
 FOR EACH ROW EXECUTE PROCEDURE basic.trigger_update_way_modified();

--- a/app/api/src/db/sql/utils.py
+++ b/app/api/src/db/sql/utils.py
@@ -1,0 +1,57 @@
+import os
+from collections import namedtuple
+from pathlib import Path
+
+
+def find_unapplied_dependencies(function_content, function_list):
+    dependencies = set()
+    for function in function_list:
+        if "." + function.name in function_content:
+            dependencies.add(function.name)
+    return dependencies
+
+
+def get_name_from_path(path) -> str:
+    """
+    to get name of function from path (file name)
+    """
+    basename = os.path.basename(path)
+    return os.path.splitext(basename)[0]
+
+
+def get_function_list_from_files(path_list):
+    function = namedtuple("function", ["path", "name", "dependencies"])
+    function_list = []
+    for path in path_list:
+        function_name = get_name_from_path(path)
+        function_list.append(function(path, function_name, set()))
+    return function_list
+
+
+def sorted_path_by_dependency(path_list):
+    """
+    The first function is not depended to any others.
+    But the last one maybe depended.
+    """
+    new_path_list = []
+    function_list = get_function_list_from_files(path_list)
+    while function_list:
+        function = function_list.pop(0)
+        function_content = Path(function.path).read_text()
+        dependencies = find_unapplied_dependencies(function_content, function_list)
+        if dependencies:
+            # found dependencies, add to the end of functions again.
+            # update dependencies
+            function.dependencies.clear()
+            function.dependencies.update(dependencies)
+            function_list.append(function)
+        else:
+            new_path_list.append(Path(function.path))
+
+    return new_path_list
+
+
+if __name__ == "__main__":
+    path_list = Path(str(Path().resolve()) + "/src/db/sql/functions").rglob("*.sql")
+    new_path_list = sorted_path_by_dependency(path_list)
+    print(new_path_list)


### PR DESCRIPTION
Up/Downgrade methods for database functions/triggers

## Description
First of all sort functions by dependencies. This sort also uses in downgrade but it is reversed.
Then, set the schema again (In fact replacing the schema) according to configurations. So we wont have functions in other schemas by accidentally set other schema or not set (So prevent adding to public).
Then have upgrade/downgrade for triggers/functions

## Motivation and Context
Used for migrating the project.

## How Has This Been Tested?
Tested by manually running the upgrade/downgrade

:warning:  upgrade/downgrade of triggers failed.

## Related Issue
closes #1368 
