### PR TITLE
Add endpoints for Opportunity Study Area Configs

### DIFF
--- a/app/api/src/endpoints/v1/api.py
+++ b/app/api/src/endpoints/v1/api.py
@@ -8,6 +8,8 @@ from src.endpoints.v1 import (
     layer_library,
     layers,
     login,
+    opportunities,
+    opportunity_config,
     organizations,
     poi_aoi,
     public_transport,
@@ -62,3 +64,9 @@ api_router.include_router(
 )
 api_router.include_router(study_area.router, prefix="/config/study-area", tags=["Layer Library"])
 api_router.include_router(geostores.router, prefix="/config/geostores", tags=["Geostores"])
+api_router.include_router(
+    opportunities.router, prefix="/config/opportunities", tags=["Opportunities"]
+)
+api_router.include_router(
+    opportunity_config.router, prefix="/config/opportunity-study-area", tags=["Opportunities"]
+)

--- a/app/api/src/endpoints/v1/opportunities.py
+++ b/app/api/src/endpoints/v1/opportunities.py
@@ -1,0 +1,36 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import crud
+from src.db import models
+from src.endpoints import deps
+
+router = APIRouter()
+
+
+@router.get("", response_model=List[models.OpportunityDefaultConfig])
+async def list_opportuniities(
+    db: AsyncSession = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    opportunities = await crud.opportunity_default_config.get_multi(db, skip=skip, limit=limit)
+    if not opportunities:
+        raise HTTPException(status_code=404, detail="there is no (more) opportunities.")
+    return opportunities
+
+
+@router.get("/groups", response_model=List[models.OpportunityGroup])
+async def list_opportuniity_groups(
+    db: AsyncSession = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    groups = await crud.opportunity_group.get_multi(db, skip=skip, limit=limit)
+    if not groups:
+        raise HTTPException(status_code=404, detail="there is no (more) groups.")
+    return groups

--- a/app/api/src/endpoints/v1/opportunities.py
+++ b/app/api/src/endpoints/v1/opportunities.py
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.get("", response_model=List[models.OpportunityDefaultConfig])
-async def list_opportuniities(
+async def list_opportunities(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
@@ -24,7 +24,7 @@ async def list_opportuniities(
 
 
 @router.get("/groups", response_model=List[models.OpportunityGroup])
-async def list_opportuniity_groups(
+async def list_opportunity_groups(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,

--- a/app/api/src/endpoints/v1/opportunity_config.py
+++ b/app/api/src/endpoints/v1/opportunity_config.py
@@ -1,0 +1,76 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import crud, schemas
+from src.db import models
+from src.endpoints import deps
+
+router = APIRouter()
+
+
+@router.get("", response_model=List[models.OpportunityStudyAreaConfig])
+async def list_opportunity_study_area_configs(
+    db: AsyncSession = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_super_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    opportunities = await crud.opportunity_study_area_config.get_multi(db, skip=skip, limit=limit)
+    if not opportunities:
+        raise HTTPException(status_code=404, detail="there is no (more) opportunities.")
+    return opportunities
+
+
+@router.get("/{id:int}", response_model=models.OpportunityStudyAreaConfig)
+async def read_opportunity_study_area_config_by_id(
+    id: int,
+    db: AsyncSession = Depends(deps.get_db),
+    current_super_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    opportunity = await crud.opportunity_study_area_config.get(db, id=id)
+    if not opportunity:
+        raise HTTPException(status_code=404, detail="opportunity not found.")
+    return opportunity
+
+
+@router.post("", response_model=models.OpportunityStudyAreaConfig)
+async def create_a_new_opportunity_study_area_config(
+    opportunity_in: schemas.CreateOpportunityStudyAreaConfig,
+    db: AsyncSession = Depends(deps.get_db),
+    current_super_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    opportunity = await crud.opportunity_study_area_config.create(db, obj_in=opportunity_in)
+    return opportunity
+
+
+@router.put("/{id:int}", response_model=models.OpportunityStudyAreaConfig)
+async def update_an_opportunity_study_area_config(
+    id: int,
+    opportunity_in: schemas.CreateOpportunityStudyAreaConfig,
+    db: AsyncSession = Depends(deps.get_db),
+    current_super_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    opportunity_in_db = await crud.opportunity_study_area_config.get(db, id=id)
+    if not opportunity_in_db:
+        raise HTTPException(status_code=404, detail="opportunity not found.")
+
+    opportunity = await crud.opportunity_study_area_config.update(
+        db, db_obj=opportunity_in_db, obj_in=opportunity_in
+    )
+    return opportunity
+
+
+@router.delete("/{id:int}", response_model=models.OpportunityStudyAreaConfig)
+async def delete_an_opportunity_study_area_config(
+    id: int,
+    db: AsyncSession = Depends(deps.get_db),
+    current_super_user: models.User = Depends(deps.get_current_active_superuser),
+):
+    opportunity = await crud.opportunity_study_area_config.get(db, id=id)
+    if not opportunity:
+        raise HTTPException(status_code=404, detail="opportunity not found.")
+
+    opportunity = await crud.opportunity_study_area_config.remove(db, id=opportunity.id)
+    return opportunity

--- a/app/api/src/schemas/__init__.py
+++ b/app/api/src/schemas/__init__.py
@@ -37,3 +37,5 @@ from .user import (
 from .layer_library import CreateLayerLibrary, CreateStyleLibrary
 
 from .geostore import CreateGeostore
+
+from .opportunity_config import CreateOpportunityStudyAreaConfig

--- a/app/api/src/schemas/opportunity_config.py
+++ b/app/api/src/schemas/opportunity_config.py
@@ -1,6 +1,7 @@
-from random import random
 from src.db import models
 from src.tests.utils.utils import random_lower_string
+from src.crud.crud_study_area import study_area as crud_study_area
+from src.crud.crud_opportunity_config import opportunity_group as crud_opportunity_group
 
 
 class RequestExample:
@@ -9,11 +10,31 @@ class RequestExample:
         return {
             "sensitivity": None,
             "multiple_entrance": True,
-            "opportunity_group_id": 14,
+            "opportunity_group_id": 12,
             "category": "test_" + random_lower_string(),
             "icon": "fas fa-train-subway-tunnel",
             "color": ["#E182A5"],
             "study_area_id": 83110000,
+            "is_active": False,
+        }
+
+    async def async_oportunity_study_area_config(self, db):
+        study_area = await crud_study_area.get_first(db=db)
+        if not study_area:
+            raise ValueError("There is no study area available")
+        opportunity_groups = await crud_opportunity_group.get_all(db=db)
+        if opportunity_groups:
+            opportunity_group = opportunity_groups[0]
+        else:
+            raise ValueError("There is no opportunity group available")
+        return {
+            "sensitivity": None,
+            "multiple_entrance": True,
+            "opportunity_group_id": opportunity_group.id,
+            "category": "test_" + random_lower_string(),
+            "icon": "fas fa-train-subway-tunnel",
+            "color": ["#E182A5"],
+            "study_area_id": study_area.id,
             "is_active": False,
         }
 

--- a/app/api/src/schemas/opportunity_config.py
+++ b/app/api/src/schemas/opportunity_config.py
@@ -1,20 +1,26 @@
+from random import random
 from src.db import models
+from src.tests.utils.utils import random_lower_string
 
 
-request_examples = {
-    "opportunity_study_area_config": {
-        "sensitivity": None,
-        "multiple_entrance": True,
-        "opportunity_group_id": 14,
-        "category": "subway_entrance",
-        "icon": "fas fa-train-subway-tunnel",
-        "color": ["#E182A5"],
-        "study_area_id": 83110000,
-        "is_active": False,
-    }
-}
+class RequestExample:
+    @property
+    def oportunity_study_area_config(self):
+        return {
+            "sensitivity": None,
+            "multiple_entrance": True,
+            "opportunity_group_id": 14,
+            "category": "test_" + random_lower_string(),
+            "icon": "fas fa-train-subway-tunnel",
+            "color": ["#E182A5"],
+            "study_area_id": 83110000,
+            "is_active": False,
+        }
+
+
+request_examples = RequestExample()
 
 
 class CreateOpportunityStudyAreaConfig(models.OpportunityStudyAreaConfig):
     class Config:
-        schema_extra = {"example": request_examples["opportunity_study_area_config"]}
+        schema_extra = {"example": request_examples.oportunity_study_area_config}

--- a/app/api/src/schemas/opportunity_config.py
+++ b/app/api/src/schemas/opportunity_config.py
@@ -1,0 +1,20 @@
+from src.db import models
+
+
+request_examples = {
+    "opportunity_study_area_config": {
+        "sensitivity": None,
+        "multiple_entrance": True,
+        "opportunity_group_id": 14,
+        "category": "subway_entrance",
+        "icon": "fas fa-train-subway-tunnel",
+        "color": ["#E182A5"],
+        "study_area_id": 83110000,
+        "is_active": False,
+    }
+}
+
+
+class CreateOpportunityStudyAreaConfig(models.OpportunityStudyAreaConfig):
+    class Config:
+        schema_extra = {"example": request_examples["opportunity_study_area_config"]}

--- a/app/api/src/tests/api/api_v1/test_opportunities.py
+++ b/app/api/src/tests/api/api_v1/test_opportunities.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import crud
+from src.core.config import settings
+from src.schemas.geostore import request_examples
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_read_oportunities_list(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    r = await client.get(
+        f"{settings.API_V1_STR}/config/opportunities", headers=superuser_token_headers
+    )
+    assert 200 <= r.status_code < 300
+    oportunities = r.json()
+    assert len(oportunities) > 1
+
+
+async def test_read_oportunity_groups_list(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    r = await client.get(
+        f"{settings.API_V1_STR}/config/opportunities/groups", headers=superuser_token_headers
+    )
+    assert 200 <= r.status_code < 300
+    groups = r.json()
+    assert len(groups) > 1

--- a/app/api/src/tests/api/api_v1/test_opportunities.py
+++ b/app/api/src/tests/api/api_v1/test_opportunities.py
@@ -1,13 +1,10 @@
 from typing import Dict
 
 import pytest
-from fastapi.encoders import jsonable_encoder
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src import crud
 from src.core.config import settings
-from src.schemas.geostore import request_examples
 
 pytestmark = pytest.mark.asyncio
 

--- a/app/api/src/tests/api/api_v1/test_opportunity_config.py
+++ b/app/api/src/tests/api/api_v1/test_opportunity_config.py
@@ -1,0 +1,104 @@
+from typing import Dict
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import crud
+from src.core.config import settings
+from src.schemas.geostore import request_examples
+from src.tests.utils.geostores import (
+    create_add_one_geostore_to_study_area,
+    create_add_two_geostores_to_study_area,
+    create_sample_geostore,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_read_geostores_list(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    await create_sample_geostore(db=db)
+    await create_sample_geostore(db=db)
+    r = await client.get(
+        f"{settings.API_V1_STR}/config/geostores", headers=superuser_token_headers
+    )
+    assert 200 <= r.status_code < 300
+    geostores = r.json()
+    assert len(geostores) > 1
+
+
+async def test_get_geostores_by_id(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    geostore = await create_sample_geostore(db=db)
+    r = await client.get(
+        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        headers=superuser_token_headers,
+    )
+    assert 200 <= r.status_code < 300
+    retrieved_geostore = r.json()
+    assert retrieved_geostore.get("id") == geostore.id
+
+
+async def test_create_geostores(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    geostore = request_examples["geostore"]
+    r = await client.post(
+        f"{settings.API_V1_STR}/config/geostores",
+        headers=superuser_token_headers,
+        json=geostore,
+    )
+    assert 200 <= r.status_code < 300
+    retrieved_geostore = r.json()
+    assert retrieved_geostore.get("name") == geostore.get("name")
+    assert retrieved_geostore.get("id")
+
+
+async def test_update_geostores(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    geostore = await create_sample_geostore(db=db)
+    geostore_id = geostore.id
+    geostore.name += "_updated"
+    r = await client.put(
+        f"{settings.API_V1_STR}/config/geostores/{geostore_id}",
+        headers=superuser_token_headers,
+        json=jsonable_encoder(geostore),
+    )
+    assert 200 <= r.status_code < 300
+    retrieved_geostore = r.json()
+    assert retrieved_geostore.get("name") == geostore.name
+    assert retrieved_geostore.get("id")
+
+
+async def test_delete_geostore(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    geostore = await create_sample_geostore(db=db)
+    r = await client.delete(
+        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        headers=superuser_token_headers,
+    )
+
+    assert 200 <= r.status_code < 300
+
+    # Try to get
+    r = await client.get(
+        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 404
+
+    # Try to delete again
+
+    r = await client.delete(
+        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 404

--- a/app/api/src/tests/api/api_v1/test_opportunity_config.py
+++ b/app/api/src/tests/api/api_v1/test_opportunity_config.py
@@ -5,82 +5,77 @@ from fastapi.encoders import jsonable_encoder
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src import crud
 from src.core.config import settings
-from src.schemas.geostore import request_examples
-from src.tests.utils.geostores import (
-    create_add_one_geostore_to_study_area,
-    create_add_two_geostores_to_study_area,
-    create_sample_geostore,
-)
+from src.schemas.opportunity_config import request_examples
+from src.tests.utils.opportunity_config import create_random_opportunity_config
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_read_geostores_list(
+async def test_read_opportunity_configs_list(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    await create_sample_geostore(db=db)
-    await create_sample_geostore(db=db)
+    await create_random_opportunity_config(db=db)
+    await create_random_opportunity_config(db=db)
     r = await client.get(
-        f"{settings.API_V1_STR}/config/geostores", headers=superuser_token_headers
+        f"{settings.API_V1_STR}/config/opportunity-study-area", headers=superuser_token_headers
     )
     assert 200 <= r.status_code < 300
-    geostores = r.json()
-    assert len(geostores) > 1
+    opportunity_configs = r.json()
+    assert len(opportunity_configs) > 1
 
 
-async def test_get_geostores_by_id(
+async def test_get_opportunity_config_by_id(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    geostore = await create_sample_geostore(db=db)
+    opportunity_config = await create_random_opportunity_config(db=db)
     r = await client.get(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config.id}",
         headers=superuser_token_headers,
     )
     assert 200 <= r.status_code < 300
-    retrieved_geostore = r.json()
-    assert retrieved_geostore.get("id") == geostore.id
+    retrieved_opportunity_config = r.json()
+    assert retrieved_opportunity_config.get("id") == opportunity_config.id
 
 
-async def test_create_geostores(
+async def test_create_opportunity_configs(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    geostore = request_examples["geostore"]
+    opportunity_config = request_examples.oportunity_study_area_config
     r = await client.post(
-        f"{settings.API_V1_STR}/config/geostores",
+        f"{settings.API_V1_STR}/config/opportunity-study-area",
         headers=superuser_token_headers,
-        json=geostore,
+        json=opportunity_config,
     )
     assert 200 <= r.status_code < 300
-    retrieved_geostore = r.json()
-    assert retrieved_geostore.get("name") == geostore.get("name")
-    assert retrieved_geostore.get("id")
+    retrieved_opportunity_config = r.json()
+    assert retrieved_opportunity_config.get("name") == opportunity_config.get("name")
+    assert retrieved_opportunity_config.get("id")
 
 
-async def test_update_geostores(
+async def test_update_opportunity_configs(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    geostore = await create_sample_geostore(db=db)
-    geostore_id = geostore.id
-    geostore.name += "_updated"
+    opportunity_config = await create_random_opportunity_config(db=db)
+    opportunity_config_id = opportunity_config.id
+    opportunity_config.category += "_updated"
     r = await client.put(
-        f"{settings.API_V1_STR}/config/geostores/{geostore_id}",
+        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config_id}",
         headers=superuser_token_headers,
-        json=jsonable_encoder(geostore),
+        json=jsonable_encoder(opportunity_config),
     )
     assert 200 <= r.status_code < 300
-    retrieved_geostore = r.json()
-    assert retrieved_geostore.get("name") == geostore.name
-    assert retrieved_geostore.get("id")
+    retrieved_opportunity_config = r.json()
+    assert retrieved_opportunity_config.get("category") == opportunity_config.category
+    assert retrieved_opportunity_config.get("id")
 
 
-async def test_delete_geostore(
+async def test_delete_opportunity_config(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    geostore = await create_sample_geostore(db=db)
+    opportunity_config = await create_random_opportunity_config(db=db)
     r = await client.delete(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config.id}",
         headers=superuser_token_headers,
     )
 
@@ -88,7 +83,7 @@ async def test_delete_geostore(
 
     # Try to get
     r = await client.get(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config.id}",
         headers=superuser_token_headers,
     )
 
@@ -97,7 +92,7 @@ async def test_delete_geostore(
     # Try to delete again
 
     r = await client.delete(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config.id}",
         headers=superuser_token_headers,
     )
 

--- a/app/api/src/tests/api/api_v1/test_opportunity_config.py
+++ b/app/api/src/tests/api/api_v1/test_opportunity_config.py
@@ -41,7 +41,7 @@ async def test_get_opportunity_config_by_id(
 async def test_create_opportunity_configs(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    opportunity_config = request_examples.oportunity_study_area_config
+    opportunity_config = await request_examples.async_oportunity_study_area_config(db=db)
     r = await client.post(
         f"{settings.API_V1_STR}/config/opportunity-study-area",
         headers=superuser_token_headers,

--- a/app/api/src/tests/utils/opportunity_config.py
+++ b/app/api/src/tests/utils/opportunity_config.py
@@ -9,7 +9,7 @@ from src.schemas.opportunity_config import request_examples
 async def create_random_opportunity_config(
     db: AsyncSession,
 ) -> models.LayerLibrary:
-    layer_library_in = request_examples.oportunity_study_area_config
+    layer_library_in = await request_examples.async_oportunity_study_area_config(db=db)
     layer_library_in = CreateOpportunityStudyAreaConfig(**layer_library_in)
     layer = await crud.opportunity_study_area_config.create(db=db, obj_in=layer_library_in)
     return layer

--- a/app/api/src/tests/utils/opportunity_config.py
+++ b/app/api/src/tests/utils/opportunity_config.py
@@ -1,0 +1,15 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src import crud
+from src.db import models
+from src.schemas import CreateOpportunityStudyAreaConfig
+from src.schemas.opportunity_config import request_examples
+
+
+async def create_random_opportunity_config(
+    db: AsyncSession,
+) -> models.LayerLibrary:
+    layer_library_in = request_examples.oportunity_study_area_config
+    layer_library_in = CreateOpportunityStudyAreaConfig(**layer_library_in)
+    layer = await crud.opportunity_study_area_config.create(db=db, obj_in=layer_library_in)
+    return layer


### PR DESCRIPTION
Endpoints for:

- List Opportunities
- List Opportunity Groups
- CRUD OpportunityStudyAreaConfig

## Description
Endpoints:

- [x] List Opportunities
- [x] List Opportunity Groups
- [x] CRUD OpportunityStudyAreaConfig

## Motivation and Context
Used in Dashboard to config study areas

## How Has This Been Tested?
:warning: Not tested yet

- [x] TEST List Opportunities
- [x] TEST List Opportunity Groups
- [x] TEST LIST OpportunityStudyAreaConfig
- [x] TEST GET OpportunityStudyAreaConfig
- [x] TEST CREATE OpportunityStudyAreaConfig
- [x] TEST UPDATE OpportunityStudyAreaConfig
- [x] TEST DELETE OpportunityStudyAreaConfig

## Screenshots (if appropriate):
![Screenshot 2022-08-12 at 18-01-52 goat](https://user-images.githubusercontent.com/3726265/184364338-63ecc1d2-d2af-499b-a39a-f0f2c0909a3c.png)

## Related Issue
#1421
