### PR TITLE
Delete multi endpoints

### DIFF
--- a/app/api/src/crud/base.py
+++ b/app/api/src/crud/base.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import RelationshipProperty, selectinload
@@ -104,6 +105,14 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         await db.delete(obj)
         await db.commit()
         return obj
+
+    async def remove_multi(self, db: AsyncSession, *, ids: Union[int, List[int]]) -> ModelType:
+        if type(ids) == int:
+            ids = [ids]
+        statement = delete(self.model).where(self.model.id.in_(ids))
+        await db.execute(statement)
+        a = await db.commit()
+        return a
 
     async def get_n_rows(self, db: AsyncSession, *, n: int) -> ModelType:
         statement = select(self.model).limit(n)

--- a/app/api/src/crud/base.py
+++ b/app/api/src/crud/base.py
@@ -111,8 +111,14 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
             ids = [ids]
         statement = delete(self.model).where(self.model.id.in_(ids))
         await db.execute(statement)
-        a = await db.commit()
-        return a
+        await db.commit()
+
+    async def remove_multi_by_key(self, db: AsyncSession, *, key: str, values: Any) -> ModelType:
+        if not type(values) == list:
+            values = [values]
+        statement = delete(self.model).where(getattr(self.model, key).in_(values))
+        await db.execute(statement)
+        await db.commit()
 
     async def get_n_rows(self, db: AsyncSession, *, n: int) -> ModelType:
         statement = select(self.model).limit(n)

--- a/app/api/src/crud/base.py
+++ b/app/api/src/crud/base.py
@@ -113,12 +113,20 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         await db.execute(statement)
         await db.commit()
 
+        # Return empty string at the moment
+        # TODO: add removed items instead.
+        return ""
+
     async def remove_multi_by_key(self, db: AsyncSession, *, key: str, values: Any) -> ModelType:
         if not type(values) == list:
             values = [values]
         statement = delete(self.model).where(getattr(self.model, key).in_(values))
         await db.execute(statement)
         await db.commit()
+
+        # Return empty string at the moment
+        # TODO: add removed items instead.
+        return ""
 
     async def get_n_rows(self, db: AsyncSession, *, n: int) -> ModelType:
         statement = select(self.model).limit(n)

--- a/app/api/src/crud/crud_scenario.py
+++ b/app/api/src/crud/crud_scenario.py
@@ -295,5 +295,9 @@ class CRUDScenario(CRUDBase[models.Scenario, schemas.ScenarioCreate, schemas.Sce
         await db.execute(statement)
         await db.commit()
 
+        # Return empty string at the moment
+        # TODO: add removed items instead.
+        return ""
+
 
 scenario = CRUDScenario(models.Scenario)

--- a/app/api/src/endpoints/v1/geostores.py
+++ b/app/api/src/endpoints/v1/geostores.py
@@ -63,13 +63,13 @@ async def update_a_geostore(
 
 
 @router.delete("")
-async def delete_a_geostore(
-    id: Union[int, List[int]],
+async def delete_geostores(
+    ids: Union[int, List[int]],
     db: AsyncSession = Depends(deps.get_db),
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.geostore.remove_multi(db, ids=id)
+    await crud.geostore.remove_multi(db, ids=ids)
     return "ok"
 
 

--- a/app/api/src/endpoints/v1/geostores.py
+++ b/app/api/src/endpoints/v1/geostores.py
@@ -62,14 +62,14 @@ async def update_a_geostore(
     return geostore
 
 
-@router.delete("")
+@router.delete("/")
 async def delete_geostores(
-    ids: Union[int, List[int]],
+    id: List[int] = Query(default=None, gt=0),
     db: AsyncSession = Depends(deps.get_db),
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.geostore.remove_multi(db, ids=ids)
+    await crud.geostore.remove_multi(db, ids=id)
     return "ok"
 
 

--- a/app/api/src/endpoints/v1/geostores.py
+++ b/app/api/src/endpoints/v1/geostores.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import List, Union
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
@@ -62,18 +62,15 @@ async def update_a_geostore(
     return geostore
 
 
-@router.delete("/{id:int}", response_model=models.Geostore)
+@router.delete("")
 async def delete_a_geostore(
-    id: int,
+    id: Union[int, List[int]],
     db: AsyncSession = Depends(deps.get_db),
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    geostore = await crud.geostore.get(db, id=id)
-    if not geostore:
-        raise HTTPException(status_code=404, detail="geostore not found.")
 
-    geostore = await crud.geostore.remove(db, id=geostore.id)
-    return geostore
+    await crud.geostore.remove_multi(db, ids=id)
+    return "ok"
 
 
 @router.get("/study_area/{study_area_id:int}", response_model=List[models.Geostore])

--- a/app/api/src/endpoints/v1/geostores.py
+++ b/app/api/src/endpoints/v1/geostores.py
@@ -62,15 +62,14 @@ async def update_a_geostore(
     return geostore
 
 
-@router.delete("")
+@router.delete("/")
 async def delete_geostores(
     id: List[int] = Query(default=None, gt=0),
     db: AsyncSession = Depends(deps.get_db),
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.geostore.remove_multi(db, ids=id)
-    return "ok"
+    return await crud.geostore.remove_multi(db, ids=id)
 
 
 @router.get("/study_area/{study_area_id:int}", response_model=List[models.Geostore])

--- a/app/api/src/endpoints/v1/geostores.py
+++ b/app/api/src/endpoints/v1/geostores.py
@@ -62,7 +62,7 @@ async def update_a_geostore(
     return geostore
 
 
-@router.delete("/")
+@router.delete("")
 async def delete_geostores(
     id: List[int] = Query(default=None, gt=0),
     db: AsyncSession = Depends(deps.get_db),

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -1,7 +1,7 @@
 import http
 from typing import List, Union
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud, schemas
@@ -65,12 +65,12 @@ async def update_a_layer_library(
 
 @router.delete("")
 async def delete_layer_libraries(
-    names: Union[str, List[str]],
+    name: List[str] = Query(default=None),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.layer_library.remove_multi_by_key(db, key="name", values=names)
+    await crud.layer_library.remove_multi_by_key(db, key="name", values=name)
     return "ok"
 
 
@@ -130,10 +130,10 @@ async def update_style(
 
 @styles_router.delete("")
 async def delete_style_libraries(
-    names: Union[str, List[str]],
+    name: List[str] = Query(default=None),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.style_library.remove_multi_by_key(db, key="name", values=names)
+    await crud.style_library.remove_multi_by_key(db, key="name", values=name)
     return "ok"

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -63,15 +63,14 @@ async def update_a_layer_library(
     return layer
 
 
-@router.delete("")
+@router.delete("/")
 async def delete_layer_libraries(
     name: List[str] = Query(default=None),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.layer_library.remove_multi_by_key(db, key="name", values=name)
-    return "ok"
+    return await crud.layer_library.remove_multi_by_key(db, key="name", values=name)
 
 
 styles_router = APIRouter()
@@ -128,12 +127,11 @@ async def update_style(
     return style
 
 
-@styles_router.delete("")
+@styles_router.delete("/")
 async def delete_style_libraries(
     name: List[str] = Query(default=None),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
 
-    await crud.style_library.remove_multi_by_key(db, key="name", values=name)
-    return "ok"
+    return await crud.style_library.remove_multi_by_key(db, key="name", values=name)

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -1,5 +1,5 @@
 import http
-from typing import List
+from typing import List, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -63,20 +63,15 @@ async def update_a_layer_library(
     return layer
 
 
-@router.delete("/{name}", response_model=models.LayerLibrary)
-async def delete_a_layer_library(
-    name: str,
+@router.delete("")
+async def delete_layer_libraries(
+    names: Union[str, List[str]],
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    layer = await crud.layer_library.get_by_key(db, key="name", value=name)
-    if not layer:
-        raise HTTPException(status_code=404, detail="layer library not found.")
-    else:
-        layer = layer[0]
 
-    layer = await crud.layer_library.remove(db, id=layer.id)
-    return layer
+    await crud.layer_library.remove_multi_by_key(db, key="name", values=names)
+    return "ok"
 
 
 styles_router = APIRouter()
@@ -133,17 +128,12 @@ async def update_style(
     return style
 
 
-@styles_router.delete("/{name}", response_model=models.StyleLibrary)
-async def delete_a_style_library(
-    name: str,
+@styles_router.delete("")
+async def delete_style_libraries(
+    names: Union[str, List[str]],
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    style = await crud.style_library.get_by_key(db, key="name", value=name)
-    if not style:
-        raise HTTPException(status_code=404, detail="style library not found.")
-    else:
-        style = style[0]
 
-    style = await crud.style_library.remove(db, id=style.id)
-    return style
+    await crud.style_library.remove_multi_by_key(db, key="name", values=names)
+    return "ok"

--- a/app/api/src/endpoints/v1/scenarios.py
+++ b/app/api/src/endpoints/v1/scenarios.py
@@ -45,7 +45,7 @@ async def create_scenario(
     obj_scenario = models.Scenario(
         scenario_name=scenario_in.scenario_name,
         user_id=current_user.id,
-        study_area_id=current_user.active_study_area_id
+        study_area_id=current_user.active_study_area_id,
     )
     result = await crud.scenario.create(db=db, obj_in=obj_scenario)
     return result
@@ -60,7 +60,10 @@ async def get_scenarios(
     """
     Get all scenarios.
     """
-    result = await crud.scenario.get_by_multi_keys(db=db, keys={"user_id": current_user.id, "study_area_id": current_user.active_study_area_id})
+    result = await crud.scenario.get_by_multi_keys(
+        db=db,
+        keys={"user_id": current_user.id, "study_area_id": current_user.active_study_area_id},
+    )
     return result
 
 
@@ -85,25 +88,18 @@ async def update_scenario(
         raise HTTPException(status_code=400, detail="Scenario not found")
 
 
-@router.delete("/{scenario_id}", response_model=Msg)
+@router.delete("/")
 async def delete_scenario(
     *,
+    id: List[int] = Query(default=None, gt=0),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_user),
-    scenario_id: int,
 ):
     """
     Delete scenario.
     """
-    scenario = await crud.scenario.get_by_multi_keys(
-        db, keys={"id": scenario_id, "user_id": current_user.id}
-    )
-    if len(scenario) > 0:
-        await db.execute("DELETE FROM customer.scenario WHERE id=:scenario_id", {"scenario_id": scenario_id})
-        await db.commit()
-        return {"msg": "Scenario deleted."}
-    else:
-        raise HTTPException(status_code=400, detail="Scenario not found")
+    await crud.scenario.remove_multi_by_id_and_userid(db, ids=id, user_id=current_user.id)
+    return "ok"
 
 
 @router.get("/{scenario_id}/upload", response_model=Msg)

--- a/app/api/src/endpoints/v1/scenarios.py
+++ b/app/api/src/endpoints/v1/scenarios.py
@@ -98,8 +98,7 @@ async def delete_scenario(
     """
     Delete scenario.
     """
-    await crud.scenario.remove_multi_by_id_and_userid(db, ids=id, user_id=current_user.id)
-    return "ok"
+    return await crud.scenario.remove_multi_by_id_and_userid(db, ids=id, user_id=current_user.id)
 
 
 @router.get("/{scenario_id}/upload", response_model=Msg)

--- a/app/api/src/endpoints/v1/static_layers_extra.py
+++ b/app/api/src/endpoints/v1/static_layers_extra.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src import crud
@@ -129,16 +129,14 @@ async def update_static_layer_data(
 @router.delete("/static")
 async def delete_static_layer_data(
     *,
-    layer_ids: Union[int, List[int]],
+    id: List[int] = Query(default=None, gt=0),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
     """
     Delete multiple static layers at the same time.
     """
-    if type(layer_ids) is int:
-        layer_ids = [layer_ids]
-
+    layer_ids = id
     for layer_id in layer_ids:
         static_layer = await crud.static_layer.get(db, id=layer_id)
         if static_layer:

--- a/app/api/src/endpoints/v1/static_layers_extra.py
+++ b/app/api/src/endpoints/v1/static_layers_extra.py
@@ -126,7 +126,7 @@ async def update_static_layer_data(
     return static_layer
 
 
-@router.delete("/static")
+@router.delete("/static/")
 async def delete_static_layer_data(
     *,
     id: List[int] = Query(default=None, gt=0),
@@ -142,6 +142,6 @@ async def delete_static_layer_data(
         if static_layer:
             # Drop PostGIS table
             await crud.static_layer.drop_postgis_table(db, static_layer.table_name)
-        # Delete Objects
-        await crud.static_layer.remove_multi(db, ids=layer_ids)
-    return "ok"
+
+    # Delete Objects
+    return await crud.static_layer.remove_multi(db, ids=layer_ids)

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -296,7 +296,7 @@ async def read_user_by_id(
     return user
 
 
-@router.delete("")
+@router.delete("/")
 async def delete_users(
     *,
     id: List[int] = Query(default=None, gt=0),
@@ -307,8 +307,7 @@ async def delete_users(
     Delete users.
     """
 
-    await crud.user.remove_multi(db, ids=id)
-    return "ok"
+    return await crud.user.remove_multi(db, ids=id)
 
 
 @router.put("/{user_id}", response_model=models.User, response_model_exclude={"hashed_password"})

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -299,7 +299,7 @@ async def read_user_by_id(
 @router.delete("")
 async def delete_users(
     *,
-    ids: Union[int, List[int]],
+    id: List[int] = Query(default=None, gt=0),
     db: AsyncSession = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ) -> Any:
@@ -307,7 +307,7 @@ async def delete_users(
     Delete users.
     """
 
-    await crud.user.remove_multi(db, ids=ids)
+    await crud.user.remove_multi(db, ids=id)
     return "ok"
 
 

--- a/app/api/src/tests/api/api_v1/test_geostores.py
+++ b/app/api/src/tests/api/api_v1/test_geostores.py
@@ -82,7 +82,7 @@ async def test_delete_geostores(
     geostores = [await create_sample_geostore(db=db) for i in range(2)]
     geostore_ids = [geostore.id for geostore in geostores]
     r = await client.delete(
-        f"{settings.API_V1_STR}/config/geostores",
+        f"{settings.API_V1_STR}/config/geostores/",
         headers=superuser_token_headers,
         params={"id": geostore_ids},
     )

--- a/app/api/src/tests/api/api_v1/test_geostores.py
+++ b/app/api/src/tests/api/api_v1/test_geostores.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict
 
 import pytest
@@ -75,33 +76,28 @@ async def test_update_geostores(
     assert retrieved_geostore.get("id")
 
 
-async def test_delete_geostore(
+async def test_delete_geostores(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    geostore = await create_sample_geostore(db=db)
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+    geostores = [await create_sample_geostore(db=db) for i in range(2)]
+    geostore_ids = [geostore.id for geostore in geostores]
+    r = await client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/config/geostores",
         headers=superuser_token_headers,
+        json=geostore_ids,
     )
 
     assert 200 <= r.status_code < 300
 
-    # Try to get
-    r = await client.get(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
-        headers=superuser_token_headers,
-    )
+    for geostore in geostores:
+        # Try to get
+        r = await client.get(
+            f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
+            headers=superuser_token_headers,
+        )
 
-    assert r.status_code == 404
-
-    # Try to delete again
-
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/geostores/{geostore.id}",
-        headers=superuser_token_headers,
-    )
-
-    assert r.status_code == 404
+        assert r.status_code == 404
 
 
 async def test_read_study_area_geostores_list(

--- a/app/api/src/tests/api/api_v1/test_geostores.py
+++ b/app/api/src/tests/api/api_v1/test_geostores.py
@@ -81,11 +81,10 @@ async def test_delete_geostores(
 ) -> None:
     geostores = [await create_sample_geostore(db=db) for i in range(2)]
     geostore_ids = [geostore.id for geostore in geostores]
-    r = await client.request(
-        "DELETE",
+    r = await client.delete(
         f"{settings.API_V1_STR}/config/geostores",
         headers=superuser_token_headers,
-        json=geostore_ids,
+        params={"id": geostore_ids},
     )
 
     assert 200 <= r.status_code < 300

--- a/app/api/src/tests/api/api_v1/test_layer_library.py
+++ b/app/api/src/tests/api/api_v1/test_layer_library.py
@@ -74,33 +74,30 @@ async def test_update_layer_library(
     assert retrieved_layer.get("id")
 
 
-async def test_delete_layer_library(
+async def test_delete_layer_libraries(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    random_layer = await create_random_layer_library(db=db)
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/library/{random_layer.name}",
+    random_layers = [await create_random_layer_library(db=db) for i in range(2)]
+    random_layer_names = [layer.name for layer in random_layers]
+    r = await client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/config/layers/library",
         headers=superuser_token_headers,
+        json=random_layer_names,
     )
 
     assert 200 <= r.status_code < 300
 
-    # Try to get
-    r = await client.get(
-        f"{settings.API_V1_STR}/config/layers/library/{random_layer.name}",
-        headers=superuser_token_headers,
-    )
+    for random_layer in random_layers:
+        # Try to get
+        r = await client.get(
+            f"{settings.API_V1_STR}/config/layers/library/{random_layer.name}",
+            headers=superuser_token_headers,
+        )
 
-    assert r.status_code == 404
+        assert r.status_code == 404
 
-    # Try to delete again
-
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/library/{random_layer.name}",
-        headers=superuser_token_headers,
-    )
-
-    assert r.status_code == 404
+        # Try to delete again
 
 
 async def test_read_styles_list(
@@ -196,30 +193,24 @@ async def test_update_style_library(
     assert retrieved_style.get("id")
 
 
-async def test_delete_style_library(
+async def test_delete_style_libraries(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    random_style = await create_random_style_library(db=db)
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/library/styles/{random_style.name}",
+    random_styles = [await create_random_style_library(db=db) for i in range(2)]
+    random_style_names = [style.name for style in random_styles]
+    r = await client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/config/layers/library/styles",
         headers=superuser_token_headers,
+        json=random_style_names,
     )
 
     assert 200 <= r.status_code < 300
+    for random_style in random_styles:
+        # Try to get
+        r = await client.get(
+            f"{settings.API_V1_STR}/config/layers/library/styles/{random_style.name}",
+            headers=superuser_token_headers,
+        )
 
-    # Try to get
-    r = await client.get(
-        f"{settings.API_V1_STR}/config/layers/library/styles/{random_style.name}",
-        headers=superuser_token_headers,
-    )
-
-    assert r.status_code == 404
-
-    # Try to delete again
-
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/library/styles/{random_style.name}",
-        headers=superuser_token_headers,
-    )
-
-    assert r.status_code == 404
+        assert r.status_code == 404

--- a/app/api/src/tests/api/api_v1/test_layer_library.py
+++ b/app/api/src/tests/api/api_v1/test_layer_library.py
@@ -79,11 +79,10 @@ async def test_delete_layer_libraries(
 ) -> None:
     random_layers = [await create_random_layer_library(db=db) for i in range(2)]
     random_layer_names = [layer.name for layer in random_layers]
-    r = await client.request(
-        "DELETE",
+    r = await client.delete(
         f"{settings.API_V1_STR}/config/layers/library",
         headers=superuser_token_headers,
-        json=random_layer_names,
+        params={"name": random_layer_names},
     )
 
     assert 200 <= r.status_code < 300
@@ -198,11 +197,10 @@ async def test_delete_style_libraries(
 ) -> None:
     random_styles = [await create_random_style_library(db=db) for i in range(2)]
     random_style_names = [style.name for style in random_styles]
-    r = await client.request(
-        "DELETE",
+    r = await client.delete(
         f"{settings.API_V1_STR}/config/layers/library/styles",
         headers=superuser_token_headers,
-        json=random_style_names,
+        params={"name": random_style_names},
     )
 
     assert 200 <= r.status_code < 300

--- a/app/api/src/tests/api/api_v1/test_layer_library.py
+++ b/app/api/src/tests/api/api_v1/test_layer_library.py
@@ -80,7 +80,7 @@ async def test_delete_layer_libraries(
     random_layers = [await create_random_layer_library(db=db) for i in range(2)]
     random_layer_names = [layer.name for layer in random_layers]
     r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/library",
+        f"{settings.API_V1_STR}/config/layers/library/",
         headers=superuser_token_headers,
         params={"name": random_layer_names},
     )
@@ -95,8 +95,6 @@ async def test_delete_layer_libraries(
         )
 
         assert r.status_code == 404
-
-        # Try to delete again
 
 
 async def test_read_styles_list(
@@ -198,7 +196,7 @@ async def test_delete_style_libraries(
     random_styles = [await create_random_style_library(db=db) for i in range(2)]
     random_style_names = [style.name for style in random_styles]
     r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/library/styles",
+        f"{settings.API_V1_STR}/config/layers/library/styles/",
         headers=superuser_token_headers,
         params={"name": random_style_names},
     )

--- a/app/api/src/tests/api/api_v1/test_scenarios.py
+++ b/app/api/src/tests/api/api_v1/test_scenarios.py
@@ -1,2 +1,36 @@
 # TODO: Test scenario endpoints
 # TODO: Don't allow to create scenario features outside of study area
+from typing import Dict
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.config import settings
+from src.tests.utils.utils import create_sample_scenario
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_delete_scenarios(
+    client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
+) -> None:
+    scenarios = [await create_sample_scenario(client, superuser_token_headers) for i in range(2)]
+    scenario_ids = [scenario["id"] for scenario in scenarios]
+    r = await client.delete(
+        f"{settings.API_V1_STR}/scenarios/",
+        headers=superuser_token_headers,
+        params={"id": scenario_ids},
+    )
+
+    assert 200 <= r.status_code < 300
+
+    # Try to get
+    r = await client.get(
+        f"{settings.API_V1_STR}/scenarios",
+        headers=superuser_token_headers,
+    )
+    r_scenarios = r.json()
+    r_scenario_ids = [scenario["id"] for scenario in r_scenarios]
+    for id in scenario_ids:
+        assert not id in r_scenario_ids

--- a/app/api/src/tests/api/api_v1/test_static_layers_extra.py
+++ b/app/api/src/tests/api/api_v1/test_static_layers_extra.py
@@ -126,7 +126,7 @@ async def test_delete_static_layers(
     static_layers = [await create_static_layer(db=db) for i in range(2)]
     static_layer_ids = [layer.id for layer in static_layers]
     r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/vector/static",
+        f"{settings.API_V1_STR}/config/layers/vector/static/",
         headers=superuser_token_headers,
         params={"id": static_layer_ids},
     )

--- a/app/api/src/tests/api/api_v1/test_static_layers_extra.py
+++ b/app/api/src/tests/api/api_v1/test_static_layers_extra.py
@@ -125,11 +125,10 @@ async def test_delete_static_layers(
 ) -> None:
     static_layers = [await create_static_layer(db=db) for i in range(2)]
     static_layer_ids = [layer.id for layer in static_layers]
-    r = await client.request(
-        "DELETE",
+    r = await client.delete(
         f"{settings.API_V1_STR}/config/layers/vector/static",
         headers=superuser_token_headers,
-        json=static_layer_ids,
+        params={"id": static_layer_ids},
     )
     assert 200 <= r.status_code < 300
     for static_layer in static_layers:

--- a/app/api/src/tests/api/api_v1/test_static_layers_extra.py
+++ b/app/api/src/tests/api/api_v1/test_static_layers_extra.py
@@ -120,19 +120,22 @@ async def test_update_static_layer(
         assert retrieved_layer.get("id") == static_layer.id
 
 
-async def test_delete_static_layer(
+async def test_delete_static_layers(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    static_layer = await create_static_layer(db=db)
-    r = await client.delete(
-        f"{settings.API_V1_STR}/config/layers/vector/static/{static_layer.id}",
+    static_layers = [await create_static_layer(db=db) for i in range(2)]
+    static_layer_ids = [layer.id for layer in static_layers]
+    r = await client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/config/layers/vector/static",
         headers=superuser_token_headers,
+        json=static_layer_ids,
     )
     assert 200 <= r.status_code < 300
+    for static_layer in static_layers:
+        r = await client.get(
+            f"{settings.API_V1_STR}/config/layers/vector/static/{static_layer.id}",
+            headers=superuser_token_headers,
+        )
 
-    r = await client.get(
-        f"{settings.API_V1_STR}/config/layers/vector/static/{static_layer.id}",
-        headers=superuser_token_headers,
-    )
-
-    assert r.status_code == 404
+        assert r.status_code == 404

--- a/app/api/src/tests/api/api_v1/test_users.py
+++ b/app/api/src/tests/api/api_v1/test_users.py
@@ -75,18 +75,19 @@ async def test_get_user_superuser(
     assert existing_user[0].email == api_user["email"]
 
 
-async def test_delete_user_superuser(
+async def test_delete_users_superuser(
     client: AsyncClient, superuser_token_headers: dict, db: AsyncSession
 ) -> None:
-    user_in = await create_random_user(db=db)
-    user_id = user_in.id
-    r = await client.delete(
-        f"{settings.API_V1_STR}/users/{user_id}",
-        headers=superuser_token_headers,
+    users = [await create_random_user(db=db) for i in range(2)]
+    user_ids = [user.id for user in users]
+    r = await client.request(
+        "DELETE", f"{settings.API_V1_STR}/users", headers=superuser_token_headers, json=user_ids
     )
     assert 200 <= r.status_code < 300
-    existing_user = await crud.user.get_by_key(db, key="email", value=user_in.email)
-    assert len(existing_user) == 0
+
+    for user_in in users:
+        existing_user = await crud.user.get_by_key(db, key="email", value=user_in.email)
+        assert len(existing_user) == 0
 
 
 async def test_update_user_superuser(

--- a/app/api/src/tests/api/api_v1/test_users.py
+++ b/app/api/src/tests/api/api_v1/test_users.py
@@ -80,8 +80,8 @@ async def test_delete_users_superuser(
 ) -> None:
     users = [await create_random_user(db=db) for i in range(2)]
     user_ids = [user.id for user in users]
-    r = await client.request(
-        "DELETE", f"{settings.API_V1_STR}/users", headers=superuser_token_headers, json=user_ids
+    r = await client.delete(
+        f"{settings.API_V1_STR}/users", headers=superuser_token_headers, params={"id": user_ids}
     )
     assert 200 <= r.status_code < 300
 

--- a/app/api/src/tests/api/api_v1/test_users.py
+++ b/app/api/src/tests/api/api_v1/test_users.py
@@ -81,7 +81,7 @@ async def test_delete_users_superuser(
     users = [await create_random_user(db=db) for i in range(2)]
     user_ids = [user.id for user in users]
     r = await client.delete(
-        f"{settings.API_V1_STR}/users", headers=superuser_token_headers, params={"id": user_ids}
+        f"{settings.API_V1_STR}/users/", headers=superuser_token_headers, params={"id": user_ids}
     )
     assert 200 <= r.status_code < 300
 

--- a/app/api/src/tests/utils/utils.py
+++ b/app/api/src/tests/utils/utils.py
@@ -3,8 +3,11 @@ import string
 from typing import Dict
 
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from src import crud, schemas
 from src.core.config import settings
+from src.db import models
 
 
 def random_lower_string() -> str:
@@ -25,3 +28,13 @@ async def get_superuser_token_headers(client: AsyncClient) -> Dict[str, str]:
     a_token = tokens["access_token"]
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
+
+
+async def create_sample_scenario(client, superuser_token_headers) -> models.Scenario:
+    r = await client.post(
+        f"{settings.API_V1_STR}/scenarios",
+        headers=superuser_token_headers,
+        json=schemas.scenario.request_examples["create"],
+    )
+    scenario = r.json()
+    return scenario


### PR DESCRIPTION
Refactor endpoints to accept more than one object to delete

:warning: This will change the functionality and form of endpoints. As we need to pass list of parameters. Previously the parameter could pass as URL part. But now they pass differently (Query params)
Example: `/geostores/?id=1&id=2&id=3`

## Description
Endpoints:

- [x] geostore.delete_geostores()
- [x] scenarios.delete_scenario()
- [x] users.delete_user()
- [x] static_layers_extra.delete_static_layer_data()
- [x] layer_library.delete_a_style_library()
- [x] layer_library.delete_a_layer_library()

### Fix :one: (convert endpoints to get input as query parameter)

- [x] geostore.delete_geostores()
- [x] scenarios.delete_scenario()
- [x] users.delete_user()
- [x] static_layers_extra.delete_static_layer_data()
- [x] layer_library.delete_a_style_library()
- [x] layer_library.delete_a_layer_library()

## How Has This Been Tested?
- [x] TEST: geostore.delete_geostores()
- [x] TEST: scenarios.delete_scenario()
- [x] TEST: users.delete_user()
- [x] TEST: static_layers_extra.delete_static_layer_data()
- [x] TEST: layer_library.delete_a_style_library()
- [x] TEST: layer_library.delete_a_layer_library()

### Fixes (convert endpoints to get input as query parameter)
- [x] TEST: geostore.delete_geostores()
- [x] TEST: scenarios.delete_scenario()
- [x] TEST: users.delete_user()
- [x] TEST: static_layers_extra.delete_static_layer_data()
- [x] TEST: layer_library.delete_a_style_library()
- [x] TEST: layer_library.delete_a_layer_library()
## Screenshots (if appropriate):

## Related Issue
#1438 
