### PR TITLE
[ADD] chapar models

### DIFF
--- a/app/api/src/db/models/__init__.py
+++ b/app/api/src/db/models/__init__.py
@@ -1,10 +1,17 @@
 from ._base_class import Base
-from ._link_model import StudyAreaGridVisualization, UserRole, UserStudyArea, StudyAreaGeostore
+from ._link_model import (
+    StudyAreaGeostore,
+    StudyAreaGridVisualization,
+    UserRole,
+    UserStudyArea,
+)
 from .aoi import Aoi, AoiBase, AoiModified, AoiUser
 from .building import Building, BuildingBase, BuildingModified
+from .chapar import DataFlow, DataMatch
 from .customization import Customization, UserCustomization
 from .data_upload import DataUpload
 from .edge import Edge, EdgeBase, WayModified
+from .geostore import Geostore
 from .grid import GridCalculation, GridVisualization
 from .heatmap import (
     ReachedEdgeFullHeatmap,
@@ -27,8 +34,5 @@ from .role import Role
 from .scenario import Scenario
 from .static_layer import StaticLayer
 from .study_area import StudyArea, SubStudyArea
-from .user import User, UserBase
-from .layer_library import LayerLibrary, StyleLibrary, LayerSource
-from .opportunity_config import OpportunityDefaultConfig, OpportunityGroup, OpportunityStudyAreaConfig, OpportunityUserConfig
-from .geostore import Geostore
 from .system import System
+from .user import User, UserBase

--- a/app/api/src/db/models/chapar.py
+++ b/app/api/src/db/models/chapar.py
@@ -1,0 +1,33 @@
+import enum
+from typing import Optional
+
+from sqlmodel import BigInteger, Enum, Field, ForeignKey, Integer, SQLModel, String
+
+
+class DataMatchModes(str, enum.Enum):
+    mtc = "Matched"
+    upd = "Update"
+    ins = "Insert"
+    dpr = "Deprecated"
+
+
+class DataFlow(SQLModel, table=True):
+    __table_args__ = {"schema": "chapar"}
+    __tablename__ = "data_flow"
+    id: int = Field(primary_key=True)
+    source_table_name: str = Field(String(65))
+    target_table_name: str = Field(String(65))
+    find_matches_finished: bool = Field(default=False)
+    find_updates_finished: bool = Field(default=False)
+    find_adds_finished: bool = Field(default=False)
+    find_deprecations_finished: bool = Field(default=False)
+
+
+class DataMatch(SQLModel, table=True):
+    __table_args__ = {"schema": "chapar"}
+    __tablename__ = "data_match"
+    id: int = Field(primary_key=True)
+    data_flow_id: int = Field(ForeignKey(DataFlow.id))
+    source_data_id: Optional[int] = Field(BigInteger(), nullable=True)
+    target_data_id: Optional[int] = Field(BigInteger(), nullable=True)
+    comparison_mode: str = Field(Enum(DataMatchModes))


### PR DESCRIPTION
+ chapar.DataFlow
+ chapar.DataMatch

## Alembic :alembic: 
Alembic revision is not included. Because these models will change in the future and it would be better not to add alembic revision at the moment.

### Chapar schema
Chapar schema (create/drop) should be added to alembic revision manually as follows:

`op.execute("create schema chapar")`

Also drop for downgrade.

#### Related issue
#1525 