### PR TITLE
Fix Isochrone result window bugs

### DIFF
--- a/app/client/src/components/isochrones/IsochroneThematicData.vue
+++ b/app/client/src/components/isochrones/IsochroneThematicData.vue
@@ -2,10 +2,9 @@
   <v-card
     v-if="isochroneResultWindow === true"
     v-draggable="draggableValue"
-    class="thematic-data elevation-4"
+    class="thematic-data elevation-4 isochrone-result"
     id="isochroneWindowId"
     :style="[isExpanded ? { height: '520px' } : { height: '50px' }]"
-    style="position:fixed;top:10px;left:400px;z-index:2;max-width:600px;min-width:370px;height:450px;overflow:hidden;"
     ondragstart="return false;"
   >
     <v-layout justify-space-between column fill-height>
@@ -515,7 +514,6 @@ export default {
       }
       return maxIsochroneRange;
     },
-
     ...mapGetters("isochrones", {
       isochroneLayer: "isochroneLayer",
       calculationColors: "calculationColors"
@@ -630,5 +628,17 @@ export default {
   width: 50px;
   border-radius: 0px;
   margin-bottom: 16px;
+}
+
+.isochrone-result {
+  position: fixed;
+  z-index: 2;
+  top: 20px;
+  /** Drawer width + 70px margin */
+  left: calc(360px + 70px);
+  max-width: 600px;
+  min-width: 370px;
+  height: 450px;
+  overflow: hidden;
 }
 </style>

--- a/app/client/src/components/isochrones/IsochroneThematicData.vue
+++ b/app/client/src/components/isochrones/IsochroneThematicData.vue
@@ -2,12 +2,12 @@
   <v-card
     v-if="isochroneResultWindow === true"
     v-draggable="draggableValue"
-    class="thematic-data elevation-4 isochrone-result"
+    class="thematic-data isochrone-result"
     id="isochroneWindowId"
     :style="[isExpanded ? { height: '520px' } : { height: '50px' }]"
     ondragstart="return false;"
   >
-    <v-layout justify-space-between column fill-height>
+    <v-layout justify-space-between column>
       <v-app-bar
         :ref="handleId"
         :color="appColor.primary"
@@ -638,7 +638,6 @@ export default {
   left: calc(360px + 70px);
   max-width: 600px;
   min-width: 370px;
-  height: 450px;
-  overflow: hidden;
+  height: fit-content;
 }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- #### Fixed Isochrone position reset after dragging it
- #### Fixed Isochrone result window size ( not scrollable now )
----
- ### Resizeable window ≠
- Due to the druggability feature of the isochrone result window, making it resizable will be such a bug candidate In different browsers and user types of browsers.
----
#1476 