### PR TITLE
Chapar remote table

### DIFF
--- a/app/api/src/core/config.py
+++ b/app/api/src/core/config.py
@@ -125,6 +125,12 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD_STAGING: Optional[str] = "secret"
     POSTGRES_OUTER_PORT_STAGING: Optional[int] = 5432
 
+    POSTGRES_DB_RAW: Optional[str] = "goat"
+    POSTGRES_SERVER_RAW: Optional[str] = "localhost"
+    POSTGRES_USER_RAW: Optional[str] = "postgres"
+    POSTGRES_PASSWORD_RAW: Optional[str] = "secret"
+    POSTGRES_OUTER_PORT_RAW: Optional[int] = 5432
+
     POSTGRES_FUNCTIONS_SCHEMA: Optional[str] = "basic"
 
     DEMO_USER_STUDY_AREA_ID: Optional[int] = 91620000  # Munich

--- a/app/api/src/db/sql/init_remote_table.py
+++ b/app/api/src/db/sql/init_remote_table.py
@@ -1,0 +1,82 @@
+from alembic_utils.pg_extension import PGExtension
+from psycopg2.errors import DuplicateObject
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+
+from src.core.config import settings
+from src.db.session import legacy_engine
+
+# postgres_fdw_sql = "CREATE EXTENSION postgres_fdw"
+
+
+def upgrade_postgres_fdw():
+    postgres_fdw = PGExtension(schema="public", signature="postgres_fdw")
+    statement = postgres_fdw.to_sql_statement_create()
+    try:
+        legacy_engine.execute(text(statement.text))
+    except ProgrammingError as exception:
+        if exception.orig.pgcode == "42710":
+            print("FWD Extension already exists on database.")
+
+
+def downgrade_postgres_fdw():
+    postgres_fdw = PGExtension(schema="public", signature="postgres_fdw")
+    statement = postgres_fdw.to_sql_statement_drop()
+    legacy_engine.execute(text(statement.text))
+
+
+def upgrade_foreign_server():
+    create_foreign_server = """
+        CREATE SERVER foreign_server
+        FOREIGN DATA WRAPPER postgres_fdw
+        OPTIONS (host :host, port :port, dbname :dbname);
+        """
+    values = {
+        "host": settings.POSTGRES_SERVER_RAW,
+        "port": "5432",
+        "dbname": settings.POSTGRES_DB_RAW,
+    }
+    create_foreign_server = text(create_foreign_server)
+    try:
+        legacy_engine.execute(create_foreign_server, values)
+    except ProgrammingError as exception:
+        if exception.orig.pgcode == "42710":
+            print(exception.orig)
+
+
+def downgrade_foreign_server():
+    drop_foreign_server = text("DROP SERVER IF EXISTS :foreign_server;")
+    values = {"foreign_server": "foreign_server"}
+    legacy_engine.execute(drop_foreign_server, values)
+
+
+# TODO local_user and foreign_server should pass dynamicly.
+# But the execute method adds quotes around them which should not for postgreSQL.
+
+
+def upgrade_mapping_user():
+    create_mapping_user = """CREATE USER MAPPING FOR postgres
+                            SERVER foreign_server
+                            OPTIONS (user :mapping_user, password :password);"""
+    create_mapping_user = text(create_mapping_user)
+    values = {
+        "local_user": settings.POSTGRES_USER,
+        "foreign_server": "foreign_server",
+        "mapping_user": "mapping_user",
+        "password": settings.POSTGRES_PASSWORD_RAW,
+    }
+    try:
+        legacy_engine.execute(create_mapping_user, values)
+    except ProgrammingError as exception:
+        if exception.orig.pgcode == "42710":
+            print(exception.orig)
+
+
+# TODO: the mapping_user and foreign_server should get dynamicly passed.
+# The problem is the same as upgrade function.
+
+
+def downgrade_mapping_user():
+    drop_mapping_user = text("DROP USER MAPPING IF EXISTS FOR mapping_user SERVER foreign_server;")
+    values = {"mapping_user": "mapping_user", "foreign_server": "foreign_server"}
+    legacy_engine.execute(drop_mapping_user, values)


### PR DESCRIPTION
The first step to do combination with Raw data and production data is to create a connection between them.
These commits are created to upgrade/downgrade:
- Foreign server extension
- Foreign server itself
- Mapping user for foreign server
- Mapping schema to import foreign tables
- Importing foreign tables to mapping schema

## Motivation and Context
Needed to prepare any database that's used for processing remote data.

## How Has This Been Tested?
:heavy_check_mark:  Manually tested for:
- upgrade_foreign_server
- downgrade_foreign_server
- upgrade_mapping_user
- downgrade_mapping_user
- upgrade_schema
- downgrade_schema
- upgrade_create_table
- downgrade_create_table

:x:  The following functions has not been tested yet:
- upgrade_extension
- downgrade_extension

## Screenshots (if appropriate):
![Screenshot from 2022-10-27 13-11-22](https://user-images.githubusercontent.com/3726265/198250707-af12514a-13b4-4bac-8510-35de8d173f8e.png)


**Related Issue** #1592 
