### PR TITLE
[FIX] Oportunity study area ocnfig endpoint bug :recycle: :lady_beetle: 

### DIFF
--- a/app/api/src/crud/base.py
+++ b/app/api/src/crud/base.py
@@ -73,6 +73,23 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         result = await db.execute(statement)
         return result.scalars().all()
 
+    async def get_multi_by_key(
+        self,
+        db: AsyncSession,
+        *,
+        key: str,
+        value: Any,
+        skip: int = 0,
+        limit: int = 100,
+        extra_fields: List[Any] = [],
+    ) -> List[ModelType]:
+        statement = (
+            select(self.model).offset(skip).limit(limit).where(getattr(self.model, key) == value)
+        )
+        statement = self.extend_statement(statement, extra_fields=extra_fields)
+        result = await db.execute(statement)
+        return result.scalars().all()
+
     async def create(self, db: AsyncSession, *, obj_in: CreateSchemaType) -> ModelType:
         db_obj = self.model.from_orm(obj_in)
         db.add(db_obj)

--- a/app/api/src/endpoints/v1/opportunity_config.py
+++ b/app/api/src/endpoints/v1/opportunity_config.py
@@ -23,13 +23,15 @@ async def list_opportunity_study_area_configs(
     return opportunities
 
 
-@router.get("/{id:int}", response_model=models.OpportunityStudyAreaConfig)
+@router.get("/{id:int}", response_model=List[models.OpportunityStudyAreaConfig])
 async def read_opportunity_study_area_config_by_id(
     id: int,
     db: AsyncSession = Depends(deps.get_db),
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    opportunity = await crud.opportunity_study_area_config.get(db, id=id)
+    opportunity = await crud.opportunity_study_area_config.get_multi_by_key(
+        db, key="study_area_id", value=id
+    )
     if not opportunity:
         raise HTTPException(status_code=404, detail="opportunity not found.")
     return opportunity

--- a/app/api/src/tests/api/api_v1/test_opportunity_config.py
+++ b/app/api/src/tests/api/api_v1/test_opportunity_config.py
@@ -1,4 +1,5 @@
 from typing import Dict
+from urllib import request
 
 import pytest
 from fastapi.encoders import jsonable_encoder
@@ -6,6 +7,8 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.config import settings
+from src.crud import crud_opportunity_config
+from src.db.models import OpportunityStudyAreaConfig
 from src.schemas.opportunity_config import request_examples
 from src.tests.utils.opportunity_config import create_random_opportunity_config
 
@@ -25,20 +28,27 @@ async def test_read_opportunity_configs_list(
     assert len(opportunity_configs) > 1
 
 
-async def test_get_opportunity_config_by_id(
+async def test_get_opportunity_study_area_config_by_id(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
-    opportunity_config = await create_random_opportunity_config(db=db)
+    try:
+        opportunity_config = await create_random_opportunity_config(db=db)
+        opportunity_config = await create_random_opportunity_config(db=db)
+    except:
+        opportunity_config = OpportunityStudyAreaConfig(
+            **request_examples.oportunity_study_area_config
+        )
     r = await client.get(
-        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config.id}",
+        f"{settings.API_V1_STR}/config/opportunity-study-area/{opportunity_config.study_area_id}",
         headers=superuser_token_headers,
     )
     assert 200 <= r.status_code < 300
-    retrieved_opportunity_config = r.json()
-    assert retrieved_opportunity_config.get("id") == opportunity_config.id
+    retrieved_opportunity_configs = r.json()
+    for r_opportunity_config in retrieved_opportunity_configs:
+        assert r_opportunity_config.get("study_area_id") == opportunity_config.study_area_id
 
 
-async def test_create_opportunity_configs(
+async def test_create_opportunity_study_area_configs(
     client: AsyncClient, superuser_token_headers: Dict[str, str], db: AsyncSession
 ) -> None:
     opportunity_config = await request_examples.async_oportunity_study_area_config(db=db)

--- a/app/api/src/tests/utils/opportunity_config.py
+++ b/app/api/src/tests/utils/opportunity_config.py
@@ -9,7 +9,7 @@ from src.schemas.opportunity_config import request_examples
 async def create_random_opportunity_config(
     db: AsyncSession,
 ) -> models.LayerLibrary:
-    layer_library_in = await request_examples.async_oportunity_study_area_config(db=db)
-    layer_library_in = CreateOpportunityStudyAreaConfig(**layer_library_in)
-    layer = await crud.opportunity_study_area_config.create(db=db, obj_in=layer_library_in)
+    opportunity_config_in = await request_examples.async_oportunity_study_area_config(db=db)
+    opportunity_config_in = CreateOpportunityStudyAreaConfig(**opportunity_config_in)
+    layer = await crud.opportunity_study_area_config.create(db=db, obj_in=opportunity_config_in)
     return layer


### PR DESCRIPTION
The endpoint previous returned the configs by the object id before and now returns all the configs related to study area.

## Motivation and Context
Used in dashboard

## How Has This Been Tested?
:heavy_check_mark: :recycle: Refactored the test.

## Related Issue
#1619
