### PR TITLE
[FIX] Add study area on user creation

### DIFF
--- a/app/api/src/crud/crud_user.py
+++ b/app/api/src/crud/crud_user.py
@@ -17,8 +17,15 @@ class CRUDUser(CRUDBase[models.User, UserCreate, UserUpdate]):
         db_obj.hashed_password = get_password_hash(obj_in.password)
         roles = await db.execute(select(models.Role).filter(models.Role.name.in_(obj_in.roles)))
         db_obj.roles = roles.scalars().all()
+
+        # combine study_area_ids with active_study_area_id
+        user_study_area_ids = set()
+        if obj_in.active_study_area_id:
+            user_study_area_ids.add(obj_in.active_study_area_id)
+        user_study_area_ids.update(obj_in.study_areas)
+
         study_areas = await db.execute(
-            select(models.StudyArea).filter(models.StudyArea.id.in_(obj_in.study_areas))
+            select(models.StudyArea).filter(models.StudyArea.id.in_(user_study_area_ids))
         )
         db_obj.study_areas = study_areas.scalars().all()
         db.add(db_obj)

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -118,7 +118,7 @@ async def create_user(
     *,
     db: AsyncSession = Depends(deps.get_db),
     user_in: schemas.UserCreate = Body(..., example=request_examples["create"]),
-    current_user: models.User = Depends(deps.get_current_active_super_user),
+    current_user: models.User = Depends(deps.get_current_active_superuser),
 ) -> Any:
     """
     Create new user.

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -118,14 +118,11 @@ async def create_user(
     *,
     db: AsyncSession = Depends(deps.get_db),
     user_in: schemas.UserCreate = Body(..., example=request_examples["create"]),
-    current_user: models.User = Depends(deps.get_current_active_user),
+    current_user: models.User = Depends(deps.get_current_active_super_user),
 ) -> Any:
     """
     Create new user.
     """
-    is_superuser = crud.user.is_superuser(current_user)
-    if not is_superuser:
-        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
 
     user = await crud.user.get_by_key(db, key="email", value=user_in.email)
     if user and len(user) > 0:


### PR DESCRIPTION
Study area id didn't add to user_study_area table for demo user endpoint.

## Description

## Motivation and Context
When user wanted to get back to the demo study area at Goat UI could not find it any more.

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Related Issue
#1543
