### PR TITLE
fix: data table of the isochrone window overflow

### DIFF
--- a/app/client/src/components/isochrones/IsochroneThematicData.vue
+++ b/app/client/src/components/isochrones/IsochroneThematicData.vue
@@ -187,7 +187,7 @@
               v-if="resultViewType === 0"
               :headers="tableHeaders"
               :items="tableItems"
-              class="elevation-1 mb-2"
+              class="elevation-1 mb-2 data-table"
               :search="search"
               hide-default-footer
               :no-data-text="
@@ -650,6 +650,11 @@ export default {
   left: calc(360px + 70px);
   max-width: 600px;
   min-width: 370px;
-  height: fit-content;
+  height: 400px;
+}
+
+.data-table {
+  max-height: 330px;
+  overflow-y: scroll;
 }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed the overflow of the isochrone result window when many POI's chosen.

## Screenshots (if appropriate):
![Screen Shot 2022-10-20 at 13 49 31](https://user-images.githubusercontent.com/42252572/196923947-fd2fa5de-0c9d-4b12-965f-cb68f2322262.png)



## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
@EPajares  Direct.

<!--- Attribution: https://github.com/stevemao/github-issue-templates -->
