### PR TITLE
[FIX] load study_areas and roles for user endpoint

### DIFF
--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -3,9 +3,12 @@ import json
 from typing import Any, List, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic.networks import EmailStr
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.collections import InstrumentedList
+from sqlalchemy.sql import select
 
 from src import crud, schemas
 from src.core.config import settings
@@ -278,25 +281,26 @@ async def deactivate_demo_users(
     return {"msg": "Demo users deactivated"}
 
 
-@router.get("/{user_id}", response_model=models.User, response_model_exclude={"hashed_password"})
+@router.get("/{user_id}")
 async def read_user_by_id(
     user_id: int,
-    current_user: models.User = Depends(deps.get_current_active_user),
+    current_user: models.User = Depends(deps.get_current_active_superuser),
     db: AsyncSession = Depends(deps.get_db),
 ) -> Any:
     """
     Get a specific user by id.
     """
-    is_superuser = crud.user.is_superuser(current_user)
-    if not is_superuser:
-        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
+    user = await crud.user.get(
+        db, id=user_id, extra_fields=[models.User.roles, models.User.study_areas]
+    )
 
-    user = await crud.user.get(db, id=user_id, extra_fields=[models.User.roles])
-    if user == current_user:
-        return user
-    if not crud.user.is_superuser(current_user):
-        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
-    return user
+    user_json = jsonable_encoder(user)
+    user_json["roles"] = [json.loads(role.json()) for role in user.roles]
+    user_json["study_areas"] = [study_area.id for study_area in user.study_areas]
+
+    del user_json["hashed_password"]
+
+    return user_json
 
 
 @router.delete("/")


### PR DESCRIPTION
As the join clause of SQLAlchemy relation, could not get serialized by pydantic, it was done by converting data to dictionary and then edit.
Also as study_area is not serializable by itself, just ids were loaded.
We can also modify it using pydantic to remove the geom column and then serialize it in future.

## Motivation and Context
Makes dashboard able to modify study areas for user

## How Has This Been Tested?
:warning: Just manual testing

## Related Issue
#1618 
