### PR TITLE
Ordering and search for endpoints

### DIFF
--- a/app/api/src/crud/base.py
+++ b/app/api/src/crud/base.py
@@ -1,8 +1,8 @@
-from operator import or_
+from operator import contains
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel
-from sqlalchemy import delete, func
+from sqlalchemy import any_, delete, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import RelationshipProperty, selectinload
@@ -43,11 +43,11 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def search(self, statement: select, query: str):
         if not hasattr(self.model.Config, "search_fields") or not query:
             return statement
-        search_objects = set()
+        search_objects = list()
         for field in self.model.Config.search_fields:
             column = getattr(self.model, field)
             containes = column.ilike(query.lower())
-            search_objects.add(containes)
+            search_objects.append(containes)
         statement = statement.filter(or_(*search_objects))
         return statement
 

--- a/app/api/src/db/models/user.py
+++ b/app/api/src/db/models/user.py
@@ -94,3 +94,6 @@ class User(UserBase, table=True):
         back_populates="user", sa_relationship_kwargs={"cascade": "all,delete,delete-orphan"}
     )
     # active_study_area: "StudyArea" = Relationship(back_populates="users_active")
+
+    class Config:
+        search_fields = ["name", "email", "surname"]

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -26,6 +26,7 @@ async def read_users(
     skip: int = 0,
     limit: int = 100,
     ordering: str = None,
+    q: str = None,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
@@ -37,7 +38,7 @@ async def read_users(
     if not is_superuser:
         raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
 
-    users = await crud.user.get_multi(db, skip=skip, limit=limit, ordering=ordering)
+    users = await crud.user.get_multi(db, skip=skip, limit=limit, ordering=ordering, query=q)
     return users
 
 

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -25,6 +25,7 @@ async def read_users(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    ordering: str = None,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
@@ -36,7 +37,7 @@ async def read_users(
     if not is_superuser:
         raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
 
-    users = await crud.user.get_multi(db, skip=skip, limit=limit)
+    users = await crud.user.get_multi(db, skip=skip, limit=limit, ordering=ordering)
     return users
 
 


### PR DESCRIPTION
Ordering and Searching for endpoints at backend

sort items example at query attribute: `sorting=-id,email`
search is added to list users endpoint. Example: `q=webmaster`

## How Has This Been Tested?
:warning: Manually tested.

## Related Issue
#1597 

<!--- Attribution: https://github.com/stevemao/github-issue-templates -->
