### PR TITLE
Ordering and search for config endpoints

### DIFF
--- a/app/api/src/crud/base.py
+++ b/app/api/src/crud/base.py
@@ -24,10 +24,10 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         """
         self.model = model
 
-    def order_by(self, statement: select, ordering: str):
-        if not ordering:
+    def order_statement(self, statement: select, order_by: str):
+        if not order_by:
             return statement
-        orders = ordering.split(",")
+        orders = order_by.split(",")
         for order in orders:
             order_ = order
             if order.startswith("-"):
@@ -100,12 +100,12 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         skip: int = 0,
         limit: int = 100,
         extra_fields: List[Any] = [],
-        ordering: str = None,
+        order_by: str = None,
         query: str = None,
     ) -> List[ModelType]:
         statement = select(self.model).offset(skip).limit(limit)
         statement = self.extend_statement(statement, extra_fields=extra_fields)
-        statement = self.order_by(statement, ordering)
+        statement = self.order_statement(statement, order_by)
         statement = self.search(statement, query)
         result = await db.execute(statement)
         return result.scalars().all()

--- a/app/api/src/db/models/geostore.py
+++ b/app/api/src/db/models/geostore.py
@@ -5,7 +5,15 @@ from sqlalchemy.dialects.postgresql import JSONB
 if TYPE_CHECKING:
     from .study_area import StudyArea
 
-from sqlmodel import Column, Field, Integer, Relationship, SQLModel, Text, UniqueConstraint
+from sqlmodel import (
+    Column,
+    Field,
+    Integer,
+    Relationship,
+    SQLModel,
+    Text,
+    UniqueConstraint,
+)
 
 from src.resources.enums import GeostoreType
 
@@ -24,9 +32,11 @@ class Geostore(SQLModel, table=True):
     attribution: str = Field(sa_column=Column(Text), nullable=False)
     thumbnail_url: str = Field(sa_column=Column(Text), nullable=False)
     study_areas: List["StudyArea"] = Relationship(
-        back_populates="geostores",
-        link_model=StudyAreaGeostore
+        back_populates="geostores", link_model=StudyAreaGeostore
     )
+
+    class Config:
+        search_fields = ["name", "type", "url", "attribution"]
 
 
 UniqueConstraint(Geostore.__table__.c.name)

--- a/app/api/src/db/models/layer_library.py
+++ b/app/api/src/db/models/layer_library.py
@@ -29,6 +29,9 @@ class StyleLibrary(SQLModel, table=True):
     translation: Optional[dict] = Field(sa_column=Column(JSONB))
     layer_libraries: "LayerLibrary" = Relationship(back_populates="style_library")
 
+    class Config:
+        search_fields = ["name"]
+
 
 UniqueConstraint(StyleLibrary.__table__.c.name)
 
@@ -49,6 +52,18 @@ class LayerLibraryBase(SQLModel):
     max_resolution: Optional[str] = Field(sa_column=Column(Text, nullable=True))
     min_resolution: Optional[str] = Field(sa_column=Column(Text, nullable=True))
     doc_url: Optional[str] = Field(sa_column=Column(Text, nullable=True))
+
+    class Config:
+        search_fields = [
+            "name",
+            "url",
+            "access_token",
+            "map_attribution",
+            "type",
+            "source",
+            "source_1",
+            "style_library_name",
+        ]
 
 
 class LayerLibrary(LayerLibraryBase, table=True):

--- a/app/api/src/db/models/opportunity_config.py
+++ b/app/api/src/db/models/opportunity_config.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING, List, Optional
 
 from sqlmodel import (
+    ARRAY,
+    Boolean,
     Column,
     Field,
     ForeignKey,
@@ -8,14 +10,12 @@ from sqlmodel import (
     Relationship,
     SQLModel,
     Text,
-    ARRAY,
     UniqueConstraint,
-    Boolean,
 )
 
 if TYPE_CHECKING:
-    from .user import User
     from .study_area import StudyArea
+    from .user import User
 
 
 class OpportunityGroup(SQLModel, table=True):
@@ -49,6 +49,9 @@ class OpportunityConfigBase(SQLModel):
     color: List[str] = Field(sa_column=Column(ARRAY(Text()), nullable=False))
     sensitivity: Optional[int] = Field(sa_column=Column(Integer))
     multiple_entrance: Optional[bool] = Field(sa_column=Column(Boolean))
+
+    class Config:
+        search_fields = ["category", "icon"]
 
 
 class OpportunityDefaultConfig(OpportunityConfigBase, table=True):
@@ -99,8 +102,7 @@ class OpportunityUserConfig(OpportunityConfigBase, table=True):
     )
     study_area_id: int = Field(sa_column=Column(Integer, ForeignKey("basic.study_area.id")))
     user_id: int = Field(
-        default=None,
-        sa_column=Column(Integer, ForeignKey("customer.user.id", ondelete="CASCADE"))
+        default=None, sa_column=Column(Integer, ForeignKey("customer.user.id", ondelete="CASCADE"))
     )
     data_upload_id: Optional[int] = Field(
         sa_column=Column(Integer, ForeignKey("customer.data_upload.id", ondelete="CASCADE"))

--- a/app/api/src/db/models/static_layer.py
+++ b/app/api/src/db/models/static_layer.py
@@ -35,7 +35,7 @@ class StaticLayer(SQLModel, table=True):
         default=None,
         sa_column=Column(
             Integer, ForeignKey("customer.user.id", ondelete="CASCADE"), nullable=False
-        )
+        ),
     )
     table_name: str = Field(sa_column=Column(String(63), nullable=False, unique=True))
 
@@ -52,3 +52,6 @@ class StaticLayer(SQLModel, table=True):
             dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
         )
         return str(raw_query)
+
+    class Config:
+        search_fields = ["table_name"]

--- a/app/api/src/endpoints/v1/geostores.py
+++ b/app/api/src/endpoints/v1/geostores.py
@@ -17,9 +17,13 @@ async def list_geostores(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    order_by: str = None,
+    q: str = None,
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    geostores = await crud.geostore.get_multi(db, skip=skip, limit=limit)
+    geostores = await crud.geostore.get_multi(
+        db, skip=skip, limit=limit, query=q, order_by=order_by
+    )
     if not geostores:
         raise HTTPException(status_code=404, detail="there is no (more) geostores.")
     return geostores

--- a/app/api/src/endpoints/v1/layer_library.py
+++ b/app/api/src/endpoints/v1/layer_library.py
@@ -16,9 +16,13 @@ async def list_layer_libraries(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    order_by: str = None,
+    q: str = None,
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    layers = await crud.layer_library.get_multi(db, skip=skip, limit=limit)
+    layers = await crud.layer_library.get_multi(
+        db, skip=skip, limit=limit, query=q, order_by=order_by
+    )
     if not layers:
         raise HTTPException(status_code=404, detail="there is no (more) layer libraries.")
     return layers
@@ -81,9 +85,13 @@ async def list_styles(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    order_by: str = None,
+    q: str = None,
     current_user: models.User = Depends(deps.get_current_active_user),
 ):
-    styles = await crud.style_library.get_multi(db, skip=skip, limit=limit)
+    styles = await crud.style_library.get_multi(
+        db, skip=skip, limit=limit, query=q, order_by=order_by
+    )
     if not styles:
         raise HTTPException(status_code=404, detail="there is no (more) style libraries.")
     return styles

--- a/app/api/src/endpoints/v1/opportunities.py
+++ b/app/api/src/endpoints/v1/opportunities.py
@@ -15,9 +15,13 @@ async def list_opportunities(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    order_by: str = None,
+    q: str = None,
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    opportunities = await crud.opportunity_default_config.get_multi(db, skip=skip, limit=limit)
+    opportunities = await crud.opportunity_default_config.get_multi(
+        db, skip=skip, limit=limit, query=q, order_by=order_by
+    )
     if not opportunities:
         raise HTTPException(status_code=404, detail="there is no (more) opportunities.")
     return opportunities

--- a/app/api/src/endpoints/v1/opportunity_config.py
+++ b/app/api/src/endpoints/v1/opportunity_config.py
@@ -15,9 +15,13 @@ async def list_opportunity_study_area_configs(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    order_by: str = None,
+    q: str = None,
     current_super_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    opportunities = await crud.opportunity_study_area_config.get_multi(db, skip=skip, limit=limit)
+    opportunities = await crud.opportunity_study_area_config.get_multi(
+        db, skip=skip, limit=limit, query=q, order_by=order_by
+    )
     if not opportunities:
         raise HTTPException(status_code=404, detail="there is no (more) opportunities.")
     return opportunities

--- a/app/api/src/endpoints/v1/static_layers_extra.py
+++ b/app/api/src/endpoints/v1/static_layers_extra.py
@@ -64,9 +64,13 @@ async def list_static_layers(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
+    order_by: str = None,
+    q: str = None,
     current_user: models.User = Depends(deps.get_current_active_superuser),
 ):
-    static_layers = await crud.static_layer.get_multi(db, skip=skip, limit=limit)
+    static_layers = await crud.static_layer.get_multi(
+        db, skip=skip, limit=limit, query=q, order_by=order_by
+    )
     if not static_layers:
         raise HTTPException(status_code=404, detail="there is no (more) static layers.")
     return static_layers

--- a/app/api/src/endpoints/v1/users.py
+++ b/app/api/src/endpoints/v1/users.py
@@ -25,7 +25,7 @@ async def read_users(
     db: AsyncSession = Depends(deps.get_db),
     skip: int = 0,
     limit: int = 100,
-    ordering: str = None,
+    order_by: str = None,
     q: str = None,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
@@ -38,7 +38,7 @@ async def read_users(
     if not is_superuser:
         raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
 
-    users = await crud.user.get_multi(db, skip=skip, limit=limit, ordering=ordering, query=q)
+    users = await crud.user.get_multi(db, skip=skip, limit=limit, order_by=order_by, query=q)
     return users
 
 


### PR DESCRIPTION
Add sort and search for config endpoints.
Also changed the key `ordering` to `order_by`
The sorting keys should separated by comma and if we want to desc order, we may add a minus (dash) before key.
For example:
`order_by=email,-id`
It first orders by email and then, if emails were same, it will order by id in desc.

Added for the following endpoints:
- /config/layers/vector/static
- /config/layers/library/styles
- /config/layers/library
- /config/geostores
- /config/opportunities
- /config/opportunity-study-area
- /users


Test: :warning: manually tested
Related issue: #1597 