### PR TITLE
[FIX] study-area-settings endpoint

### DIFF
--- a/app/api/src/schemas/study_area.py
+++ b/app/api/src/schemas/study_area.py
@@ -40,6 +40,7 @@ GROUP_ORDER = [
     "additional_data",
     "basemap",
     "heatmap",
+    "indicator",
 ]
 
 # Used for output, Doesn't fetch database
@@ -50,6 +51,7 @@ class LayerGroupBase(BaseModel):
     additional_data: Optional[List[str]] = []
     basemap: Optional[List[str]] = []
     heatmap: Optional[List[str]] = []
+    indicator: Optional[List[str]] = []
 
     def listify_config(self) -> Dict:
         """


### PR DESCRIPTION
Fix for update/get layer_groups of study_area
Missed indicator for LayerGroupBase

Related issue: #1653 