### PR TITLE
Fix gravity parenting

### DIFF
--- a/app/api/src/core/heatmap_cython.pyx
+++ b/app/api/src/core/heatmap_cython.pyx
@@ -6,20 +6,20 @@ import cython
 def get_h3_parents(h3_array: np.ndarray, int resolution):
     """Get the parent of each H3 index in the array at the given resolution.
     """
-
+    parent: cython.uint64_t
     if h3_array is None:
         return None
     if not h3_array.size:
         return h3_array.copy()
     cache = {}
     out = np.empty(h3_array.size, np.uint64)
-    for i in range(h3_array.size):
-        parent = cache.get(h3_array[i], None)
-        if parent is None:
-            parent = h3._cy.parent(h3_array[i], resolution)
-            cache[h3_array[i]] = parent
+    for i , h3_index in enumerate(h3_array):
+        parent = cache.get(h3_index, 0)
+        if not parent:
+            parent = h3._cy.parent(h3_index, resolution)
+            cache[h3_index] = parent
         out[i] = parent
-        # out[i] = h3._cy.parent(h3_array[i], resolution)
+        # out[i] = h3._cy.parent(h3_index, resolution)
     return out
 
 def convert_to_parents(h3_array: np.ndarray, int resolution):

--- a/app/api/src/core/heatmap_cython.pyx
+++ b/app/api/src/core/heatmap_cython.pyx
@@ -11,9 +11,15 @@ def get_h3_parents(h3_array: np.ndarray, int resolution):
         return None
     if not h3_array.size:
         return h3_array.copy()
+    cache = {}
     out = np.empty(h3_array.size, np.uint64)
     for i in range(h3_array.size):
-        out[i] = h3._cy.parent(h3_array[i], resolution)
+        parent = cache.get(h3_array[i], None)
+        if parent is None:
+            parent = h3._cy.parent(h3_array[i], resolution)
+            cache[h3_array[i]] = parent
+        out[i] = parent
+        # out[i] = h3._cy.parent(h3_array[i], resolution)
     return out
 
 def convert_to_parents(h3_array: np.ndarray, int resolution):

--- a/app/api/src/core/heatmap_cython.pyx
+++ b/app/api/src/core/heatmap_cython.pyx
@@ -32,6 +32,7 @@ def create_grid_pointers(grids_unordered_map:dict, parent_tags:dict):
     grid_pointers = {}
     get_id = lambda tag: grids_unordered_map.get(tag, -1)
     for key, parent_tag in parent_tags.items():
+        parent_tag = parent_tag[0]
         if not parent_tag.size:
             grid_pointers[key] = parent_tag.copy()
             continue

--- a/app/api/src/crud/crud_read_heatmap.py
+++ b/app/api/src/crud/crud_read_heatmap.py
@@ -447,7 +447,7 @@ class CRUDReadHeatmap(CRUDBaseHeatmap):
 
             end = time.time()
             print(f"Reading matrices took {end - begin} seconds")
-
+            grid_ids = self.convert_grid_ids_to_parent(grid_ids, heatmap_settings.resolution)
             # TODO: Pick right function that correspond the heatmap the user want to calculate
             sorted_table, uniques = self.sort_and_unique(
                 grid_ids, traveltimes
@@ -611,6 +611,13 @@ class CRUDReadHeatmap(CRUDBaseHeatmap):
         polygons = np.load(polygons_file_name)
         return grids, polygons
 
+    def convert_grid_ids_to_parent(self, grid_ids: dict, target_resolution: int):
+        for key, grid_id in grid_ids.items():
+            if not grid_id.size:
+                continue
+            grid_ids[key] = heatmap_cython.get_h3_parents(grid_id, target_resolution)
+        return grid_ids
+
     @timing
     def tag_uniques_by_parent(self, uniques: dict, target_resolution: int):
         """
@@ -697,9 +704,9 @@ class CRUDReadHeatmap(CRUDBaseHeatmap):
         target_resolution = h3.h3_get_resolution(sample_grid_id)
         #############################################
 
-        uniques_parent_tags = self.tag_uniques_by_parent(uniques, target_resolution)
+        # uniques_parent_tags = self.tag_uniques_by_parent(uniques, target_resolution)
         grids_unordered_map = self.create_grids_unordered_map(grids)
-        grid_pointer = self.create_grid_pointers(grids_unordered_map, uniques_parent_tags)
+        grid_pointer = self.create_grid_pointers(grids_unordered_map, uniques)
         calculations = self.create_calculation_arrays(grids, grid_pointer, calculations)
         return calculations
 


### PR DESCRIPTION
Related issue: #1933 

Removed sorted grids from sorting function:
- Sorted grids converted data types from int to float that corrupted
- Also made sorting slower
- As we don't use sorted grids it's removed