### PR TITLE
Isochrone to celery

### DIFF
--- a/app/api/src/endpoints/v1/indicators.py
+++ b/app/api/src/endpoints/v1/indicators.py
@@ -62,11 +62,12 @@ async def calculate_isochrone(
     if isochrone_in.scenario.id:
         await deps.check_user_owns_scenario(db, isochrone_in.scenario.id, current_user)
 
-    user_access_starting_point = await crud.user.user_study_area_starting_point_access(
-        db, current_user.id, isochrone_in.starting_point.input
-    )
-    if not user_access_starting_point:
-        raise HTTPException(detail="User has no access to starting point", status_code=403)
+    if isochrone_in.is_single:
+        user_access_starting_point = await crud.user.user_study_area_starting_point_access(
+            db, current_user.id, isochrone_in.starting_point.input
+        )
+        if not user_access_starting_point:
+            raise HTTPException(detail="User has no access to starting point", status_code=403)
 
     study_area = await crud.user.get_active_study_area(db, current_user)
     study_area_bounds = study_area["bounds"]


### PR DESCRIPTION
## Changes
- Changed `crud_isochrone.calculate()` result from Response to byte
- Extracted study_area_bounds from `crud_isochrone.calculate()` out, as it was async. So it is fetched at endpoint.
- The result of `calculate()` is converted to hex string first and then saved to REDIS and converted back at results endpoint.

Related issue:

- #2073 
- #1841 
- #1828 
- #1739 