### PR TITLE
[DOC] sort request examples for heatmaps

### DIFF
--- a/app/api/src/schemas/heatmap.py
+++ b/app/api/src/schemas/heatmap.py
@@ -513,3 +513,14 @@ request_examples = {
         },
     },
 }
+
+# sort request_examples by resolution
+try:
+    request_examples = {k: v for k, v in sorted(request_examples.items(), key=lambda item: item[1]['value']['resolution'])}
+except Exception:
+    pass
+
+# add warning to request_examples with high resolution
+for key, value in request_examples.items():
+    if value["value"]["resolution"] > 6:
+        request_examples[key]["summary"] += " (Warning! May freeze browser.)"


### PR DESCRIPTION
+ Sort request examples by resolution
+ Add warning to the examples with higher resolution

Related issue:
- #2086 