### PR TITLE
[FIX] Bug with pois when loading

### DIFF
--- a/app/client/src/store/modules/poisaois.js
+++ b/app/client/src/store/modules/poisaois.js
@@ -89,6 +89,7 @@ const actions = {
                 state.rawPoisAois[oneFeature.get("category")].push(oneFeature);
               } else {
                 state.rawPoisAois[oneFeature.get("category")] = [];
+                state.rawPoisAois[oneFeature.get("category")].push(oneFeature);
               }
             });
 
@@ -125,6 +126,9 @@ const actions = {
                 );
               } else {
                 state.rawGroupPoisAois[oneFeature.get("category")] = [];
+                state.rawGroupPoisAois[oneFeature.get("category")].push(
+                  oneFeature
+                );
               }
             });
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a problem that basically the first POI from a category was not added to the POI object in the poi visualization layer. This leaded to the situation that one poi per category was missing in the visualization layer.

@Ebubeker 