### PR TITLE
fix: fixed the multiisochrone window

### DIFF
--- a/app/client/src/components/isochrones/IsochroneThematicData.vue
+++ b/app/client/src/components/isochrones/IsochroneThematicData.vue
@@ -607,7 +607,7 @@ export default {
         // Update new calculation
         this.updateIsochroneSurface(newSelection[newSelection.length - 1]);
       }
-      console.log(newSelection);
+      
       if (this.selectedCalculations[0].type == "multiple") {
         this.resultViewType = 0;
       }

--- a/app/client/src/components/isochrones/IsochroneThematicData.vue
+++ b/app/client/src/components/isochrones/IsochroneThematicData.vue
@@ -607,6 +607,10 @@ export default {
         // Update new calculation
         this.updateIsochroneSurface(newSelection[newSelection.length - 1]);
       }
+      console.log(newSelection);
+      if (this.selectedCalculations[0].type == "multiple") {
+        this.resultViewType = 0;
+      }
     }
   },
   mounted() {


### PR DESCRIPTION
Managed to fix the thematic data window when a multi isochron and a single isochrone are chosen. The issue was that when we activated single isochrone, switched to the graphs and tried to activate the multi isochrone, the resultViewType variable will still stay at the graphs eventho we changed selection and isochrone type. So I listened to isochrone selection changes and checked if it was a multi isochrone. if yes, I made it that it shows only the first resultViewType, which is the table.